### PR TITLE
Support Touches

### DIFF
--- a/ZIGSIMPlus.xcodeproj/project.pbxproj
+++ b/ZIGSIMPlus.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		02E7F84A22939E25002B55F2 /* TouchMonitoringCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E7F84922939E25002B55F2 /* TouchMonitoringCommand.swift */; };
+		02E7F84C2293A864002B55F2 /* TouchDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E7F84B2293A864002B55F2 /* TouchDataStore.swift */; };
 		634B8D93228565F00043607D /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634B8D92228565F00043607D /* Command.swift */; };
 		902EB9CA227BE68D008F1650 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902EB9C9227BE68D008F1650 /* AppDelegate.swift */; };
 		902EB9CC227BE68D008F1650 /* CommandSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902EB9CB227BE68D008F1650 /* CommandSelectionViewController.swift */; };
@@ -43,6 +45,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		02E7F84922939E25002B55F2 /* TouchMonitoringCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchMonitoringCommand.swift; sourceTree = "<group>"; };
+		02E7F84B2293A864002B55F2 /* TouchDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchDataStore.swift; sourceTree = "<group>"; };
 		634B8D92228565F00043607D /* Command.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
 		902EB9C6227BE68D008F1650 /* ZIGSIMPlus.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ZIGSIMPlus.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		902EB9C9227BE68D008F1650 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -96,6 +100,7 @@
 			isa = PBXGroup;
 			children = (
 				9092E4CE227EC9880019F1C1 /* BatteryMonitoringCommand.swift */,
+				02E7F84922939E25002B55F2 /* TouchMonitoringCommand.swift */,
 				9092E4D2227EE3890019F1C1 /* AccelerationMonitoringCommand.swift */,
 			);
 			path = Commands;
@@ -187,6 +192,7 @@
 			children = (
 				903BA770227D6C2100A2C378 /* AppSettingModel.swift */,
 				634B8D92228565F00043607D /* Command.swift */,
+				02E7F84B2293A864002B55F2 /* TouchDataStore.swift */,
 				634B8D94228566C30043607D /* Commands */,
 			);
 			path = Models;
@@ -330,6 +336,8 @@
 				9092E4CA227D8ADF0019F1C1 /* CommandOutputViewController.swift in Sources */,
 				902EB9CA227BE68D008F1650 /* AppDelegate.swift in Sources */,
 				9092E4CC227EBF4D0019F1C1 /* LabelConstants.swift in Sources */,
+				02E7F84A22939E25002B55F2 /* TouchMonitoringCommand.swift in Sources */,
+				02E7F84C2293A864002B55F2 /* TouchDataStore.swift in Sources */,
 				903BA771227D6C2100A2C378 /* AppSettingModel.swift in Sources */,
 				9092E4D1227ECCFA0019F1C1 /* CommandOutputPresenter.swift in Sources */,
 				634B8D93228565F00043607D /* Command.swift in Sources */,

--- a/ZIGSIMPlus/Base.lproj/Main.storyboard
+++ b/ZIGSIMPlus/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="IOA-8y-vNV">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="IOA-8y-vNV">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -23,7 +23,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="CommandCell" id="BFY-6s-yrI">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="CommandCell" id="BFY-6s-yrI">
                                         <rect key="frame" x="0.0" y="28" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="BFY-6s-yrI" id="udW-do-XvV">
@@ -54,17 +54,24 @@
         <scene sceneID="VPf-eW-ozY">
             <objects>
                 <viewController id="AD7-px-bC2" customClass="CommandOutputViewController" customModule="ZIGSIMPlus" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="sgs-Rz-2jq">
+                    <view key="view" multipleTouchEnabled="YES" contentMode="scaleToFill" id="sgs-Rz-2jq">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="w9T-O2-Ptu">
                                 <rect key="frame" x="16" y="20" width="343" height="598"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <accessibility key="accessibilityConfiguration">
+                                    <accessibilityTraits key="traits" notEnabled="YES"/>
+                                </accessibility>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
+                            <view multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VFr-by-ckd" userLabel="Touch Area">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>

--- a/ZIGSIMPlus/Entities/LabelConstants.swift
+++ b/ZIGSIMPlus/Entities/LabelConstants.swift
@@ -11,7 +11,8 @@ import Foundation
 public struct LabelConstants {
     public static let accelaration = "Acceleration"
     public static let battery = "Battery"
-    public static let autoUpdatedCommands: [String] = [accelaration]
+    public static let touch = "Touch"
+    public static let autoUpdatedCommands: [String] = [accelaration, touch]
     public static let manualUpdatedCommands: [String] = [battery]
     
     public static var commands: [String] {

--- a/ZIGSIMPlus/Models/Commands/TouchMonitoringCommand.swift
+++ b/ZIGSIMPlus/Models/Commands/TouchMonitoringCommand.swift
@@ -15,23 +15,25 @@ public final class TouchMonitoringCommand: AutoUpdatedCommand {
             var stringMsg = ""
             
             for touch in touches {
+                let point = touch.location(in: touch.view!)
+                
                 // Position
                 stringMsg += """
-                touch:x:\(touch.point.x)
-                touch:y:\(touch.point.y)
+                touch:x:\(point.x)
+                touch:y:\(point.y)
                 
                 """
                 
                 // touch radius
                 if #available(iOS 8.0, *) {
-                    stringMsg += "touch:radius:\(touch.touch.majorRadius)\n"
+                    stringMsg += "touch:radius:\(touch.majorRadius)\n"
                 } else {
                     // Fallback on earlier versions
                 }
                 
                 // 3d touch
                 if #available(iOS 9.0, *) {
-                    stringMsg += "touch:force:\(touch.touch.force)\n"
+                    stringMsg += "touch:force:\(touch.force)\n"
                 } else {
                     // Fallback on earlier versions
                 }

--- a/ZIGSIMPlus/Models/Commands/TouchMonitoringCommand.swift
+++ b/ZIGSIMPlus/Models/Commands/TouchMonitoringCommand.swift
@@ -1,0 +1,51 @@
+//
+//  TouchMonitoringCommand.swift
+//  ZIGSIMPlus
+//
+//  Created by Takayosi Amagi on 2019/05/21.
+//  Copyright © 2019 Nozomu Kuwae. All rights reserved.
+//
+
+import Foundation
+
+public final class TouchMonitoringCommand: AutoUpdatedCommand {
+    
+    public func start(completion: ((String?) -> Void)?) {
+        TouchDataStore.shared.callback = { (touches) in
+            var stringMsg = ""
+            
+            for touch in touches {
+                // Position
+                stringMsg += """
+                touch:x:\(touch.point.x)
+                touch:y:\(touch.point.y)
+                
+                """
+                
+                // touch radius
+                if #available(iOS 8.0, *) {
+                    stringMsg += "touch:radius:\(touch.touch.majorRadius)\n"
+                } else {
+                    // Fallback on earlier versions
+                }
+                
+                // 3d touch
+                if #available(iOS 9.0, *) {
+                    stringMsg += "touch:force:\(touch.touch.force)\n"
+                } else {
+                    // Fallback on earlier versions
+                }
+                
+            }
+            
+            completion?(stringMsg)
+        }
+        
+        TouchDataStore.shared.enable()
+    }
+    
+    public func stop(completion: ((String?) -> Void)?) {
+        TouchDataStore.shared.disable()
+        completion?(nil)
+    }
+}

--- a/ZIGSIMPlus/Models/TouchDataStore.swift
+++ b/ZIGSIMPlus/Models/TouchDataStore.swift
@@ -67,6 +67,20 @@ public class TouchDataStore {
         update()
     }
     
+    func updateTouches(_ touchesToUpdate: [TouchData]) {
+        if !isEnabled { return }
+
+        for touchToUpdate in touchesToUpdate {
+            for (i, t) in touchPoints.enumerated() {
+                if t.touch == touchToUpdate.touch {
+                    touchPoints[i] = touchToUpdate
+                    break
+                }
+            }
+        }
+        update()
+    }
+
     func removeAllTouches() {
         if !isEnabled { return }
         

--- a/ZIGSIMPlus/Models/TouchDataStore.swift
+++ b/ZIGSIMPlus/Models/TouchDataStore.swift
@@ -58,7 +58,7 @@ public class TouchDataStore {
         
         for touchToRemove in touchesToRemove {
             for (i, t) in touchPoints.enumerated() {
-                if t.touch == touchToRemove.touch && t.point == touchToRemove.point {
+                if t.touch == touchToRemove.touch {
                     touchPoints.remove(at: i)
                     break
                 }

--- a/ZIGSIMPlus/Models/TouchDataStore.swift
+++ b/ZIGSIMPlus/Models/TouchDataStore.swift
@@ -9,16 +9,6 @@
 import Foundation
 import UIKit
 
-public struct TouchData {
-    let touch: UITouch
-    let point: CGPoint
-//    public var hash(into hasher: inout Hasher) {
-//        get {
-//            return touch.hashValue &* 31 &+ point.hashValue
-//        }
-//    }
-}
-
 public class TouchDataStore {
     // Singleton instance
     static let shared = TouchDataStore()
@@ -26,12 +16,12 @@ public class TouchDataStore {
     // MARK: - Instance Properties
     
     var isEnabled: Bool
-    var touchPoints: [TouchData]
-    var callback: (([TouchData]) -> Void)?
+    var touchPoints: [UITouch]
+    var callback: (([UITouch]) -> Void)?
 
     private init() {
         isEnabled = false
-        touchPoints = [TouchData]()
+        touchPoints = [UITouch]()
         callback = nil
     }
     
@@ -46,19 +36,19 @@ public class TouchDataStore {
         touchPoints.removeAll() // Reset data
     }
     
-    func addTouches(_ touches: [TouchData]) {
+    func addTouches(_ touches: Set<UITouch>) {
         if !isEnabled { return }
         
         touchPoints.append(contentsOf: touches)
         update()
     }
     
-    func removeTouches(_ touchesToRemove: [TouchData]) {
+    func removeTouches(_ touchesToRemove: Set<UITouch>) {
         if !isEnabled { return }
         
         for touchToRemove in touchesToRemove {
             for (i, t) in touchPoints.enumerated() {
-                if t.touch == touchToRemove.touch {
+                if t == touchToRemove {
                     touchPoints.remove(at: i)
                     break
                 }
@@ -67,12 +57,12 @@ public class TouchDataStore {
         update()
     }
     
-    func updateTouches(_ touchesToUpdate: [TouchData]) {
+    func updateTouches(_ touchesToUpdate: Set<UITouch>) {
         if !isEnabled { return }
 
         for touchToUpdate in touchesToUpdate {
             for (i, t) in touchPoints.enumerated() {
-                if t.touch == touchToUpdate.touch {
+                if t == touchToUpdate {
                     touchPoints[i] = touchToUpdate
                     break
                 }

--- a/ZIGSIMPlus/Models/TouchDataStore.swift
+++ b/ZIGSIMPlus/Models/TouchDataStore.swift
@@ -1,0 +1,81 @@
+//
+//  TouchDataStore.swift
+//  ZIGSIMPlus
+//
+//  Created by Takayosi Amagi on 2019/05/21.
+//  Copyright © 2019 Nozomu Kuwae. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+public struct TouchData {
+    let touch: UITouch
+    let point: CGPoint
+//    public var hash(into hasher: inout Hasher) {
+//        get {
+//            return touch.hashValue &* 31 &+ point.hashValue
+//        }
+//    }
+}
+
+public class TouchDataStore {
+    // Singleton instance
+    static let shared = TouchDataStore()
+    
+    // MARK: - Instance Properties
+    
+    var isEnabled: Bool
+    var touchPoints: [TouchData]
+    var callback: (([TouchData]) -> Void)?
+
+    private init() {
+        isEnabled = false
+        touchPoints = [TouchData]()
+        callback = nil
+    }
+    
+    // MARK: - Public methods
+    
+    func enable() {
+        isEnabled = true
+    }
+    
+    func disable() {
+        isEnabled = false
+        touchPoints.removeAll() // Reset data
+    }
+    
+    func addTouches(_ touches: [TouchData]) {
+        if !isEnabled { return }
+        
+        touchPoints.append(contentsOf: touches)
+        update()
+    }
+    
+    func removeTouches(_ touchesToRemove: [TouchData]) {
+        if !isEnabled { return }
+        
+        for touchToRemove in touchesToRemove {
+            for (i, t) in touchPoints.enumerated() {
+                if t.touch == touchToRemove.touch && t.point == touchToRemove.point {
+                    touchPoints.remove(at: i)
+                    break
+                }
+            }
+        }
+        update()
+    }
+    
+    func removeAllTouches() {
+        if !isEnabled { return }
+        
+        touchPoints.removeAll()
+        update()
+    }
+    
+    private func update() {
+        print("touchpoint:\(touchPoints.count)")
+        callback?(touchPoints)
+    }
+}

--- a/ZIGSIMPlus/PresenterFactory.swift
+++ b/ZIGSIMPlus/PresenterFactory.swift
@@ -19,6 +19,7 @@ class PresenterFactory {
         let presenter = CommandOutputPresenter()
         presenter.view = view
         presenter.autoUpdatedCommands[LabelConstants.accelaration] = AccelerationMonitoringCommand()
+        presenter.autoUpdatedCommands[LabelConstants.touch] = TouchMonitoringCommand()
         presenter.manualUpdatedCommands[LabelConstants.battery] = BatteryMonitoringCommand()
         return presenter
     }

--- a/ZIGSIMPlus/Views/CommandOutputViewController.swift
+++ b/ZIGSIMPlus/Views/CommandOutputViewController.swift
@@ -26,23 +26,16 @@ class CommandOutputViewController: UIViewController {
 
     // MARK: - Touch Events
 
-    private func touchesWithPoints(_ touches: Set<UITouch>) -> [TouchData] {
-        return touches.map {
-            let pos = $0.location(in: view!)
-            return TouchData(touch: $0, point: pos)
-        }
-    }
-
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        TouchDataStore.shared.addTouches(touchesWithPoints(touches))
+        TouchDataStore.shared.addTouches(touches)
     }   
 
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
-        TouchDataStore.shared.updateTouches(touchesWithPoints(touches))
+        TouchDataStore.shared.updateTouches(touches)
     }
 
     override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
-        TouchDataStore.shared.removeTouches(touchesWithPoints(touches))
+        TouchDataStore.shared.removeTouches(touches)
     }
 
     override func touchesCancelled(_ touches: Set<UITouch>?, with event: UIEvent?) {

--- a/ZIGSIMPlus/Views/CommandOutputViewController.swift
+++ b/ZIGSIMPlus/Views/CommandOutputViewController.swift
@@ -23,6 +23,31 @@ class CommandOutputViewController: UIViewController {
     override func viewDidDisappear(_ animated: Bool) {
         presenter.stopCommands()
     }
+
+    // MARK: - Touch Events
+
+    private func touchesWithPoints(_ touches: Set<UITouch>) -> [TouchData] {
+        return touches.map {
+            let pos = $0.location(in: view!)
+            return TouchData(touch: $0, point: pos)
+        }
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        TouchDataStore.shared.addTouches(touchesWithPoints(touches))
+    }   
+
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+        // TBD
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        TouchDataStore.shared.removeTouches(touchesWithPoints(touches))
+    }
+
+    override func touchesCancelled(_ touches: Set<UITouch>?, with event: UIEvent?) {
+        TouchDataStore.shared.removeAllTouches()
+    }
 }
 
 extension CommandOutputViewController: CommandOutputPresenterDelegate {

--- a/ZIGSIMPlus/Views/CommandOutputViewController.swift
+++ b/ZIGSIMPlus/Views/CommandOutputViewController.swift
@@ -38,7 +38,7 @@ class CommandOutputViewController: UIViewController {
     }   
 
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
-        // TBD
+        TouchDataStore.shared.updateTouches(touchesWithPoints(touches))
     }
 
     override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {


### PR DESCRIPTION
This PR adds touches command to ZIG SIM Plus.
We can see following data in the output view:

- Touch position (x, y)
- Touch radius
- Touch force

Currently we don't have a way to toggle each features.
I'll implement them once advanced settings view is ready.

## For reviewers

I didn't want to manage data in ViewController, so I created a singleton named `TouchDataStore`. 
The data flow is like this:

- Register callback to TouchDataStore from TouchMonitoringCommand
- CommandOutputViewController detects touches
- Save touch data to TouchDataStore
- TouchDataStore calls callback