### PR TITLE
Support iBeacon

### DIFF
--- a/ZIGSIMPlus.xcodeproj/project.pbxproj
+++ b/ZIGSIMPlus.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		02EBC27C2295078500377F6E /* BeaconMonitoringCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EBC27B2295078500377F6E /* BeaconMonitoringCommand.swift */; };
+		02EBC27E229508A900377F6E /* LocationDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EBC27D229508A900377F6E /* LocationDataStore.swift */; };
 		634B8D93228565F00043607D /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634B8D92228565F00043607D /* Command.swift */; };
 		63C02A2C2293D97700551E2F /* CommandAndCommandDataMediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C02A2B2293D97700551E2F /* CommandAndCommandDataMediator.swift */; };
 		902EB9CA227BE68D008F1650 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902EB9C9227BE68D008F1650 /* AppDelegate.swift */; };
@@ -46,6 +47,7 @@
 
 /* Begin PBXFileReference section */
 		02EBC27B2295078500377F6E /* BeaconMonitoringCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeaconMonitoringCommand.swift; sourceTree = "<group>"; };
+		02EBC27D229508A900377F6E /* LocationDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationDataStore.swift; sourceTree = "<group>"; };
 		634B8D92228565F00043607D /* Command.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
 		63C02A2B2293D97700551E2F /* CommandAndCommandDataMediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandAndCommandDataMediator.swift; sourceTree = "<group>"; };
 		902EB9C6227BE68D008F1650 /* ZIGSIMPlus.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ZIGSIMPlus.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -191,6 +193,7 @@
 			isa = PBXGroup;
 			children = (
 				903BA770227D6C2100A2C378 /* AppSettingModel.swift */,
+				02EBC27D229508A900377F6E /* LocationDataStore.swift */,
 				634B8D92228565F00043607D /* Command.swift */,
 				63C02A2B2293D97700551E2F /* CommandAndCommandDataMediator.swift */,
 				634B8D94228566C30043607D /* Commands */,
@@ -341,6 +344,7 @@
 				634B8D93228565F00043607D /* Command.swift in Sources */,
 				63C02A2C2293D97700551E2F /* CommandAndCommandDataMediator.swift in Sources */,
 				9092E4D5227F0D420019F1C1 /* PresenterFactory.swift in Sources */,
+				02EBC27E229508A900377F6E /* LocationDataStore.swift in Sources */,
 				02EBC27C2295078500377F6E /* BeaconMonitoringCommand.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ZIGSIMPlus.xcodeproj/project.pbxproj
+++ b/ZIGSIMPlus.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		02EBC27C2295078500377F6E /* BeaconMonitoringCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EBC27B2295078500377F6E /* BeaconMonitoringCommand.swift */; };
 		634B8D93228565F00043607D /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634B8D92228565F00043607D /* Command.swift */; };
 		63C02A2C2293D97700551E2F /* CommandAndCommandDataMediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C02A2B2293D97700551E2F /* CommandAndCommandDataMediator.swift */; };
 		902EB9CA227BE68D008F1650 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902EB9C9227BE68D008F1650 /* AppDelegate.swift */; };
@@ -44,6 +45,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		02EBC27B2295078500377F6E /* BeaconMonitoringCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeaconMonitoringCommand.swift; sourceTree = "<group>"; };
 		634B8D92228565F00043607D /* Command.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
 		63C02A2B2293D97700551E2F /* CommandAndCommandDataMediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandAndCommandDataMediator.swift; sourceTree = "<group>"; };
 		902EB9C6227BE68D008F1650 /* ZIGSIMPlus.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ZIGSIMPlus.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -98,6 +100,7 @@
 			isa = PBXGroup;
 			children = (
 				9092E4CE227EC9880019F1C1 /* BatteryMonitoringCommand.swift */,
+				02EBC27B2295078500377F6E /* BeaconMonitoringCommand.swift */,
 				9092E4D2227EE3890019F1C1 /* MotionMonitoringCommand.swift */,
 			);
 			path = Commands;
@@ -338,6 +341,7 @@
 				634B8D93228565F00043607D /* Command.swift in Sources */,
 				63C02A2C2293D97700551E2F /* CommandAndCommandDataMediator.swift in Sources */,
 				9092E4D5227F0D420019F1C1 /* PresenterFactory.swift in Sources */,
+				02EBC27C2295078500377F6E /* BeaconMonitoringCommand.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ZIGSIMPlus.xcodeproj/project.pbxproj
+++ b/ZIGSIMPlus.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		02EBC27C2295078500377F6E /* BeaconMonitoringCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EBC27B2295078500377F6E /* BeaconMonitoringCommand.swift */; };
 		02EBC27E229508A900377F6E /* LocationDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EBC27D229508A900377F6E /* LocationDataStore.swift */; };
+		02EBC2802295266E00377F6E /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EBC27F2295266E00377F6E /* Utils.swift */; };
 		634B8D93228565F00043607D /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = 634B8D92228565F00043607D /* Command.swift */; };
 		63C02A2C2293D97700551E2F /* CommandAndCommandDataMediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C02A2B2293D97700551E2F /* CommandAndCommandDataMediator.swift */; };
 		902EB9CA227BE68D008F1650 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902EB9C9227BE68D008F1650 /* AppDelegate.swift */; };
@@ -48,6 +49,7 @@
 /* Begin PBXFileReference section */
 		02EBC27B2295078500377F6E /* BeaconMonitoringCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeaconMonitoringCommand.swift; sourceTree = "<group>"; };
 		02EBC27D229508A900377F6E /* LocationDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationDataStore.swift; sourceTree = "<group>"; };
+		02EBC27F2295266E00377F6E /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		634B8D92228565F00043607D /* Command.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
 		63C02A2B2293D97700551E2F /* CommandAndCommandDataMediator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandAndCommandDataMediator.swift; sourceTree = "<group>"; };
 		902EB9C6227BE68D008F1650 /* ZIGSIMPlus.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ZIGSIMPlus.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -193,6 +195,7 @@
 			isa = PBXGroup;
 			children = (
 				903BA770227D6C2100A2C378 /* AppSettingModel.swift */,
+				02EBC27F2295266E00377F6E /* Utils.swift */,
 				02EBC27D229508A900377F6E /* LocationDataStore.swift */,
 				634B8D92228565F00043607D /* Command.swift */,
 				63C02A2B2293D97700551E2F /* CommandAndCommandDataMediator.swift */,
@@ -337,6 +340,7 @@
 				9092E4D3227EE3890019F1C1 /* MotionMonitoringCommand.swift in Sources */,
 				902EB9CC227BE68D008F1650 /* CommandDataSelectionViewController.swift in Sources */,
 				9092E4CA227D8ADF0019F1C1 /* CommandDataOutputViewController.swift in Sources */,
+				02EBC2802295266E00377F6E /* Utils.swift in Sources */,
 				902EB9CA227BE68D008F1650 /* AppDelegate.swift in Sources */,
 				9092E4CC227EBF4D0019F1C1 /* LabelConstants.swift in Sources */,
 				903BA771227D6C2100A2C378 /* AppSettingModel.swift in Sources */,

--- a/ZIGSIMPlus/Entities/LabelConstants.swift
+++ b/ZIGSIMPlus/Entities/LabelConstants.swift
@@ -12,5 +12,6 @@ public struct LabelConstants {
     public static let acceleration = "Acceleration"
     public static let gravity = "Gravity"
     public static let battery = "Battery"
-    public static let commandDatas: [String] = [acceleration, gravity, battery]
+    public static let beacon = "Beacon"
+    public static let commandDatas: [String] = [acceleration, gravity, battery, beacon]
 }

--- a/ZIGSIMPlus/Info.plist
+++ b/ZIGSIMPlus/Info.plist
@@ -41,5 +41,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Beacons</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Beacons</string>
 </dict>
 </plist>

--- a/ZIGSIMPlus/Models/AppSettingModel.swift
+++ b/ZIGSIMPlus/Models/AppSettingModel.swift
@@ -23,5 +23,7 @@ public class AppSettingModel {
         return 1.0 / Double(messageRatePerSecond)
     }
     
-    let beaconUUID = "B9407F30-F5F8-466E-AFF9-25556B570000" // TODO: Get value from settings view
+    // TODO: Save values to device storage like UserDefaults
+    let deviceUUID:String = Utils.randomStringWithLength(16)
+    let beaconUUID = "B9407F30-F5F8-466E-AFF9-25556B570000"
 }

--- a/ZIGSIMPlus/Models/AppSettingModel.swift
+++ b/ZIGSIMPlus/Models/AppSettingModel.swift
@@ -22,4 +22,6 @@ public class AppSettingModel {
     var messageInterval: TimeInterval {
         return 1.0 / Double(messageRatePerSecond)
     }
+    
+    let beaconUUID = "B9407F30-F5F8-466E-AFF9-25556B570000" // TODO: Get value from settings view
 }

--- a/ZIGSIMPlus/Models/CommandAndCommandDataMediator.swift
+++ b/ZIGSIMPlus/Models/CommandAndCommandDataMediator.swift
@@ -18,10 +18,14 @@ public class CommandAndCommandDataMediator {
             return (b1 || b2)
         } else if type(of: command) == BatteryMonitoringCommand.self {
             guard let b = AppSettingModel.shared.isActiveByCommandData[LabelConstants.battery]
-            else { fatalError("AppSetting of the CommandData nil") }
+                else { fatalError("AppSetting of the CommandData nil") }
+            return b
+        } else if type(of: command) == BeaconMonitoringCommand.self {
+            guard let b = AppSettingModel.shared.isActiveByCommandData[LabelConstants.beacon]
+                else { fatalError("AppSetting of the CommandData nil") }
             return b
         }
-        
+
         fatalError("Unexpected Command")
     }
     
@@ -30,6 +34,8 @@ public class CommandAndCommandDataMediator {
             return 1
         } else if type(of: command) == BatteryMonitoringCommand.self {
             return 2
+        } else if type(of: command) == BeaconMonitoringCommand.self {
+            return 3
         }
         
         fatalError("Unexpected Command")

--- a/ZIGSIMPlus/Models/Commands/BeaconMonitoringCommand.swift
+++ b/ZIGSIMPlus/Models/Commands/BeaconMonitoringCommand.swift
@@ -1,0 +1,46 @@
+//
+//  BeaconMonitoringCommand.swift
+//  ZIGSIMPlus
+//
+//  Created by Takayosi Amagi on 2019/05/22.
+//  Copyright © 2019 Nozomu Kuwae. All rights reserved.
+//
+
+import Foundation
+
+public final class BeaconMonitoringCommand: AutoUpdatedCommand {
+    
+    public func start(completion: ((String?) -> Void)?) {
+//        if motionManager.isAccelerometerAvailable {
+        if true {
+//            motionManager.accelerometerUpdateInterval = AppSettingModel.shared.messageInterval
+//            motionManager.startAccelerometerUpdates(to: OperationQueue.current!) { (accelerationData, error) in
+//                guard error == nil else {
+//                    completion?(error!.localizedDescription)
+//                    return
+//                }
+//
+//                guard let accelData = accelerationData else {
+//                    completion?("no accel data")
+//                    return
+//                }
+//
+//                completion?("""
+//                    accel:x:\(accelData.acceleration.x)
+//                    accel:y:\(accelData.acceleration.y)
+//                    accel:z:\(accelData.acceleration.z)
+//                    """)
+//            }
+            completion?("woooooooooooooo")
+        } else {
+            completion?("accel unavailable")
+        }
+    }
+    
+    public func stop(completion: ((String?) -> Void)?) {
+//        if (motionManager.isAccelerometerActive) {
+//            motionManager.stopAccelerometerUpdates()
+//        }
+        completion?(nil)
+    }
+}

--- a/ZIGSIMPlus/Models/Commands/BeaconMonitoringCommand.swift
+++ b/ZIGSIMPlus/Models/Commands/BeaconMonitoringCommand.swift
@@ -9,38 +9,23 @@
 import Foundation
 
 public final class BeaconMonitoringCommand: AutoUpdatedCommand {
-    
+
     public func start(completion: ((String?) -> Void)?) {
-//        if motionManager.isAccelerometerAvailable {
-        if true {
-//            motionManager.accelerometerUpdateInterval = AppSettingModel.shared.messageInterval
-//            motionManager.startAccelerometerUpdates(to: OperationQueue.current!) { (accelerationData, error) in
-//                guard error == nil else {
-//                    completion?(error!.localizedDescription)
-//                    return
-//                }
-//
-//                guard let accelData = accelerationData else {
-//                    completion?("no accel data")
-//                    return
-//                }
-//
-//                completion?("""
-//                    accel:x:\(accelData.acceleration.x)
-//                    accel:y:\(accelData.acceleration.y)
-//                    accel:z:\(accelData.acceleration.z)
-//                    """)
-//            }
-            completion?("woooooooooooooo")
-        } else {
-            completion?("accel unavailable")
+        LocationDataStore.shared.beaconsCallback = { (beacons) in
+            var stringMsg = ""
+            
+            for (i, b) in beacons.enumerated() {
+                stringMsg += "Beacon \(i): uuid:\(b.proximityUUID.uuidString) major:\(b.major.intValue) minor:\(b.minor.intValue) rssi:\(b.rssi)\n"
+            }
+            
+            completion?(stringMsg)
         }
+        
+        LocationDataStore.shared.enable()
     }
-    
+
     public func stop(completion: ((String?) -> Void)?) {
-//        if (motionManager.isAccelerometerActive) {
-//            motionManager.stopAccelerometerUpdates()
-//        }
+        LocationDataStore.shared.disable()
         completion?(nil)
     }
 }

--- a/ZIGSIMPlus/Models/LocationDataStore.swift
+++ b/ZIGSIMPlus/Models/LocationDataStore.swift
@@ -1,0 +1,105 @@
+//
+//  LocationDataStore.swift
+//  ZIGSIMPlus
+//
+//  Created by Takayosi Amagi on 2019/05/22.
+//  Copyright © 2019 Nozomu Kuwae. All rights reserved.
+//
+
+import Foundation
+import CoreLocation
+
+public class LocationDataStore: NSObject {
+    // Singleton instance
+    static let shared = LocationDataStore()
+    
+    // MARK: - Instance Properties
+    
+    private var isEnabled: Bool = false
+    private var isAuthorized: Bool = false
+    private let locationManager: CLLocationManager = CLLocationManager()
+    private let beaconRegion : CLBeaconRegion
+    private var beacons: [CLBeacon] = [CLBeacon]()
+    var beaconsCallback: (([CLBeacon]) -> Void)? = nil
+    
+    private override init() {
+        // Init beacons
+        let appSetting = AppSettingModel.shared
+        let uuid = UUID(uuidString: appSetting.beaconUUID)!
+        let deviceUUID = "12345678" // TODO: replace with AppSettingModel.shared.deviceUUID
+        beaconRegion = CLBeaconRegion(proximityUUID: uuid, identifier: "\(deviceUUID) region")
+        beaconsCallback = nil
+    }
+    
+    // MARK: - Public methods
+    
+    func enable() {
+        isEnabled = true
+        
+        if #available(iOS 8.0, *) {
+            locationManager.delegate = self
+            if isAuthorized {
+                locationManager.startMonitoring(for: beaconRegion)
+                locationManager.startRangingBeacons(in: beaconRegion)
+            }
+            else {
+                locationManager.requestAlwaysAuthorization()
+            }
+        } else {
+            // Fallback on earlier versions
+        }
+    }
+    
+    func disable() {
+        isEnabled = false
+        if isAuthorized {
+            locationManager.stopRangingBeacons(in: beaconRegion)
+            locationManager.stopMonitoring(for: beaconRegion)
+        }
+        beacons.removeAll() // Reset data
+    }
+
+    private func updateBeacons() {
+        print("beacons:\(beacons.count)")
+        beaconsCallback?(beacons)
+    }
+}
+
+extension LocationDataStore: CLLocationManagerDelegate {
+    public func locationManager(_ manager: CLLocationManager, didStartMonitoringFor region: CLRegion) {
+        print("Start monitoring for iBeacon")
+    }
+    
+    public func locationManager(_ manager: CLLocationManager, didRangeBeacons newBeacons: [CLBeacon], in region: CLBeaconRegion) {
+        for b in newBeacons {
+            // Check if the beacon is already registered
+            let index = beacons.firstIndex(where: {
+                $0.proximityUUID == b.proximityUUID && $0.major == b.major && $0.minor == b.minor
+            })
+            
+            if index == nil {
+                // Add beacon data
+                print("Found iBeacon: uuid:\(b.proximityUUID.uuidString) major:\(b.major.intValue) minor:\(b.minor.intValue) rssi:\(b.rssi)")
+                beacons.append(b)
+            }
+            else {
+                // Update beacon data
+                beacons[index!] = b
+                print("Updated iBeacon: uuid:\(b.proximityUUID.uuidString) major:\(b.major.intValue) minor:\(b.minor.intValue) rssi:\(b.rssi)")
+            }
+        }
+        updateBeacons()
+    }
+    
+    public func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+        switch status {
+        case .authorizedAlways, .authorizedWhenInUse:
+            isAuthorized = true
+            locationManager.startMonitoring(for: beaconRegion)
+            locationManager.startRangingBeacons(in: beaconRegion)
+            break;
+        default:
+            break;
+        }
+    }
+}

--- a/ZIGSIMPlus/Models/LocationDataStore.swift
+++ b/ZIGSIMPlus/Models/LocationDataStore.swift
@@ -29,7 +29,7 @@ public class LocationDataStore: NSObject {
         // Init beacons
         let appSetting = AppSettingModel.shared
         let uuid = UUID(uuidString: appSetting.beaconUUID)!
-        let deviceUUID = "12345678" // TODO: replace with AppSettingModel.shared.deviceUUID
+        let deviceUUID =  appSetting.deviceUUID
         beaconRegion = CLBeaconRegion(proximityUUID: uuid, identifier: "\(deviceUUID) region")
         beaconsCallback = nil
     }

--- a/ZIGSIMPlus/Models/LocationDataStore.swift
+++ b/ZIGSIMPlus/Models/LocationDataStore.swift
@@ -9,8 +9,11 @@
 import Foundation
 import CoreLocation
 
+/// Data store for commands which depend on LocationManager.
+/// e.g.) GPS, iBeacon, etc.
 public class LocationDataStore: NSObject {
-    // Singleton instance
+
+    /// Singleton instance
     static let shared = LocationDataStore()
     
     // MARK: - Instance Properties
@@ -30,7 +33,7 @@ public class LocationDataStore: NSObject {
         beaconRegion = CLBeaconRegion(proximityUUID: uuid, identifier: "\(deviceUUID) region")
         beaconsCallback = nil
     }
-    
+
     // MARK: - Public methods
     
     func enable() {
@@ -43,6 +46,7 @@ public class LocationDataStore: NSObject {
                 locationManager.startRangingBeacons(in: beaconRegion)
             }
             else {
+                // Request authorization if needed
                 locationManager.requestAlwaysAuthorization()
             }
         } else {
@@ -59,17 +63,23 @@ public class LocationDataStore: NSObject {
         beacons.removeAll() // Reset data
     }
 
+    // MARK: - Private methods
+    
     private func updateBeacons() {
         print("beacons:\(beacons.count)")
         beaconsCallback?(beacons)
     }
 }
 
+// MARK: - CLLocationManagerDelegate methods
+
 extension LocationDataStore: CLLocationManagerDelegate {
+    // Called when the device started monitoring
     public func locationManager(_ manager: CLLocationManager, didStartMonitoringFor region: CLRegion) {
         print("Start monitoring for iBeacon")
     }
     
+    // Called when new data is received from beacons
     public func locationManager(_ manager: CLLocationManager, didRangeBeacons newBeacons: [CLBeacon], in region: CLBeaconRegion) {
         for b in newBeacons {
             // Check if the beacon is already registered
@@ -91,6 +101,7 @@ extension LocationDataStore: CLLocationManagerDelegate {
         updateBeacons()
     }
     
+    // Called when the user authorized monitorin location data
     public func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
         switch status {
         case .authorizedAlways, .authorizedWhenInUse:

--- a/ZIGSIMPlus/Models/Utils.swift
+++ b/ZIGSIMPlus/Models/Utils.swift
@@ -1,0 +1,16 @@
+//
+//  Utils.swift
+//  ZIGSIMPlus
+//
+//  Created by Takayosi Amagi on 2019/05/22.
+//  Copyright © 2019 Nozomu Kuwae. All rights reserved.
+//
+
+import Foundation
+
+class Utils {
+    static func randomStringWithLength(_ length: Int) -> String {
+        let alphabet = "-_1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        return String((0..<length).map { _ -> Character in alphabet.randomElement()! })
+    }
+}

--- a/ZIGSIMPlus/PresenterFactory.swift
+++ b/ZIGSIMPlus/PresenterFactory.swift
@@ -22,6 +22,7 @@ class PresenterFactory {
         presenter.mediator = mediator
         presenter.commands.append(MotionMonitoringCommand())
         presenter.commands.append(BatteryMonitoringCommand())
+        presenter.commands.append(BeaconMonitoringCommand())
         return presenter
     }
 }


### PR DESCRIPTION
This PR adds iBeacon command to ZIG SIM Plus.
We can see following data in the output view:

- iBeacon UUID
- major
- minor
- rssi

iBeacon UUID is hard coded: `B9407F30-F5F8-466E-AFF9-25556B570000`
I'll make it configurable once settings view is ready.

## For reviewers
I added `LocationDataStore`, which is like `TouchDataStore` in #2 .
But `LocationDataStore` should be used in other features using `CLLocationManager` like GPS.

## Screenshot
![beacon 2019-05-22 16_27_59](https://user-images.githubusercontent.com/1403842/58155321-98ba2300-7cae-11e9-9e3a-73a9ee9b8b28.gif)
