### PR TITLE
Support GPS&COMPASS

### DIFF
--- a/ZIGSIMPlus.xcodeproj/project.pbxproj
+++ b/ZIGSIMPlus.xcodeproj/project.pbxproj
@@ -24,6 +24,9 @@
 		9092E4D1227ECCFA0019F1C1 /* CommandDataOutputPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9092E4D0227ECCFA0019F1C1 /* CommandDataOutputPresenter.swift */; };
 		9092E4D3227EE3890019F1C1 /* MotionMonitoringCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9092E4D2227EE3890019F1C1 /* MotionMonitoringCommand.swift */; };
 		9092E4D5227F0D420019F1C1 /* PresenterFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9092E4D4227F0D420019F1C1 /* PresenterFactory.swift */; };
+		B394C0B322950F2F00706BB3 /* GpsCompassData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B394C0B222950F2E00706BB3 /* GpsCompassData.swift */; };
+		B394C0B522950FDB00706BB3 /* GpsMonitoringCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = B394C0B422950FDB00706BB3 /* GpsMonitoringCommand.swift */; };
+		B394C0B72295100500706BB3 /* CompassMonitoringCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = B394C0B62295100500706BB3 /* CompassMonitoringCommand.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -67,6 +70,9 @@
 		9092E4D0227ECCFA0019F1C1 /* CommandDataOutputPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandDataOutputPresenter.swift; sourceTree = "<group>"; };
 		9092E4D2227EE3890019F1C1 /* MotionMonitoringCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MotionMonitoringCommand.swift; sourceTree = "<group>"; };
 		9092E4D4227F0D420019F1C1 /* PresenterFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresenterFactory.swift; sourceTree = "<group>"; };
+		B394C0B222950F2E00706BB3 /* GpsCompassData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GpsCompassData.swift; sourceTree = "<group>"; };
+		B394C0B422950FDB00706BB3 /* GpsMonitoringCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GpsMonitoringCommand.swift; sourceTree = "<group>"; };
+		B394C0B62295100500706BB3 /* CompassMonitoringCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompassMonitoringCommand.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -99,6 +105,8 @@
 			children = (
 				9092E4CE227EC9880019F1C1 /* BatteryMonitoringCommand.swift */,
 				9092E4D2227EE3890019F1C1 /* MotionMonitoringCommand.swift */,
+				B394C0B422950FDB00706BB3 /* GpsMonitoringCommand.swift */,
+				B394C0B62295100500706BB3 /* CompassMonitoringCommand.swift */,
 			);
 			path = Commands;
 			sourceTree = "<group>";
@@ -187,6 +195,7 @@
 		9092E4C7227D85890019F1C1 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				B394C0B222950F2E00706BB3 /* GpsCompassData.swift */,
 				903BA770227D6C2100A2C378 /* AppSettingModel.swift */,
 				634B8D92228565F00043607D /* Command.swift */,
 				63C02A2B2293D97700551E2F /* CommandAndCommandDataMediator.swift */,
@@ -334,9 +343,12 @@
 				902EB9CA227BE68D008F1650 /* AppDelegate.swift in Sources */,
 				9092E4CC227EBF4D0019F1C1 /* LabelConstants.swift in Sources */,
 				903BA771227D6C2100A2C378 /* AppSettingModel.swift in Sources */,
+				B394C0B522950FDB00706BB3 /* GpsMonitoringCommand.swift in Sources */,
 				9092E4D1227ECCFA0019F1C1 /* CommandDataOutputPresenter.swift in Sources */,
 				634B8D93228565F00043607D /* Command.swift in Sources */,
 				63C02A2C2293D97700551E2F /* CommandAndCommandDataMediator.swift in Sources */,
+				B394C0B72295100500706BB3 /* CompassMonitoringCommand.swift in Sources */,
+				B394C0B322950F2F00706BB3 /* GpsCompassData.swift in Sources */,
 				9092E4D5227F0D420019F1C1 /* PresenterFactory.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ZIGSIMPlus/Entities/LabelConstants.swift
+++ b/ZIGSIMPlus/Entities/LabelConstants.swift
@@ -12,5 +12,7 @@ public struct LabelConstants {
     public static let acceleration = "Acceleration"
     public static let gravity = "Gravity"
     public static let battery = "Battery"
-    public static let commandDatas: [String] = [acceleration, gravity, battery]
+    public static let compass = "Compass"
+    public static let gps     = "Gps"
+    public static let commandDatas: [String] = [acceleration, gravity, battery, compass, gps]
 }

--- a/ZIGSIMPlus/Info.plist
+++ b/ZIGSIMPlus/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string></string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/ZIGSIMPlus/Models/CommandAndCommandDataMediator.swift
+++ b/ZIGSIMPlus/Models/CommandAndCommandDataMediator.swift
@@ -20,6 +20,14 @@ public class CommandAndCommandDataMediator {
             guard let b = AppSettingModel.shared.isActiveByCommandData[LabelConstants.battery]
             else { fatalError("AppSetting of the CommandData nil") }
             return b
+        } else if type(of: command) == CompassMonitoringCommand.self {
+            guard let b = AppSettingModel.shared.isActiveByCommandData[LabelConstants.compass]
+            else { fatalError("AppSetting of the CommandData nil") }
+            return b
+        } else if type(of: command) == GpsMonitoringCommand.self {
+            guard let b = AppSettingModel.shared.isActiveByCommandData[LabelConstants.gps]
+            else { fatalError("AppSetting of the CommandData nil") }
+            return b
         }
         
         fatalError("Unexpected Command")
@@ -30,6 +38,10 @@ public class CommandAndCommandDataMediator {
             return 1
         } else if type(of: command) == BatteryMonitoringCommand.self {
             return 2
+        } else if type(of: command) == CompassMonitoringCommand.self {
+            return 3
+        } else if type(of: command) == GpsMonitoringCommand.self {
+            return 4
         }
         
         fatalError("Unexpected Command")

--- a/ZIGSIMPlus/Models/Commands/CompassMonitoringCommand.swift
+++ b/ZIGSIMPlus/Models/Commands/CompassMonitoringCommand.swift
@@ -1,0 +1,31 @@
+//
+//  CompassMonitoringCommand.swift
+//  ZIGSIMPlus
+//
+//  Created by YoneyamaShunpei on 2019/05/22.
+//  Copyright © 2019 Nozomu Kuwae. All rights reserved.
+//
+
+import Foundation
+import CoreLocation
+
+public final class CompassMonitoringCommand: AutoUpdatedCommand {
+    
+    public func start(completion: ((String?) -> Void)?) {
+        GpsCompassData.shared.startCompass()
+        GpsCompassData.shared.callbackCompass = { (compassData) in
+            // compass:faceupは設定画面作成後に追加
+            completion?("""
+                compass:compass:\(compassData)
+                compass:faceup:
+                """)
+        }
+    }
+    
+    public func stop(completion: ((String?) -> Void)?) {
+        GpsCompassData.shared.stopCompass()
+        completion?(nil)
+    }
+}
+
+

--- a/ZIGSIMPlus/Models/Commands/GpsMonitoringCommand.swift
+++ b/ZIGSIMPlus/Models/Commands/GpsMonitoringCommand.swift
@@ -1,0 +1,28 @@
+//
+//  GpsMonitoringCommand.swift
+//  ZIGSIMPlus
+//
+//  Created by YoneyamaShunpei on 2019/05/22.
+//  Copyright © 2019 Nozomu Kuwae. All rights reserved.
+//
+
+import Foundation
+import CoreLocation
+
+public final class GpsMonitoringCommand: AutoUpdatedCommand {
+    
+    public func start(completion: ((String?) -> Void)?) {
+        GpsCompassData.shared.startGps()
+        GpsCompassData.shared.callbackGps = { (gpsData) in
+            completion?("""
+                compass:latitude:\(gpsData[0])
+                compass:longitude:\(gpsData[1])
+                """)
+        }
+    }
+    
+    public func stop(completion: ((String?) -> Void)?) {
+        GpsCompassData.shared.stopGps()
+        completion?(nil)
+    }
+}

--- a/ZIGSIMPlus/Models/GpsCompassData.swift
+++ b/ZIGSIMPlus/Models/GpsCompassData.swift
@@ -1,0 +1,104 @@
+//
+//  LocationData.swift
+//  ZIGSIMPlus
+//
+//  Created by YoneyamaShunpei on 2019/05/22.
+//  Copyright © 2019 Nozomu Kuwae. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import CoreLocation
+
+public class GpsCompassData :NSObject,CLLocationManagerDelegate {
+    // Singleton instance
+    static let shared = GpsCompassData()
+    
+    // MARK: - Instance Properties
+    var callbackGps: (([Double]) -> Void)?
+    var callbackCompass: ((Double) -> Void)?
+    var latitudeData: Double
+    var longitudeData: Double
+    var compassData: Double
+    var locationManager: CLLocationManager?
+    
+    private override init() {
+        callbackGps = nil
+        callbackCompass = nil
+        latitudeData = 0.0
+        longitudeData = 0.0
+        compassData = 0.0
+        super.init()
+        if #available(iOS 8.0, *) {
+            if CLLocationManager.locationServicesEnabled() {
+                self.locationManager = CLLocationManager()
+                self.locationManager?.requestWhenInUseAuthorization()
+                self.locationManager?.delegate = self;
+                self.locationManager?.distanceFilter = 1.0
+                self.locationManager?.desiredAccuracy = kCLLocationAccuracyBest
+                /* T.B.D 設定画面で向きを設定変更できるようにする↓ */
+                self.locationManager?.headingOrientation = .faceUp
+                //self.locationManager?.headingOrientation = .portrait
+            }
+        }
+        
+    }
+    
+    private func updateCompassData() {
+        print("compassData:\(self.compassData)")
+        callbackCompass?(self.compassData)
+    }
+    
+    private func updateGpsData() {
+        print("gpsData:latitudeData:\(self.latitudeData)")
+        print("gpsData:longitudeData:\(self.longitudeData)")
+        var gpsData = [0.0,0.0]
+        gpsData[0] = self.latitudeData
+        gpsData[1] = self.longitudeData
+        callbackGps?(gpsData)
+    }
+    
+    public func locationManager(_ manager:CLLocationManager, didUpdateHeading newHeading: CLHeading) {
+        self.compassData = newHeading.magneticHeading
+        updateCompassData()
+    }
+    
+    public final func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        self.latitudeData = (locations.last?.coordinate.latitude)!
+        self.longitudeData = (locations.last?.coordinate.longitude)!
+        updateGpsData()
+    }
+    
+    // MARK: - Public methods
+    func startGps() {
+        if #available(iOS 8.0, *) {
+            if CLLocationManager.locationServicesEnabled() {
+                self.locationManager?.startUpdatingLocation()
+            }
+        }
+    }
+    
+    func stopGps() {
+        if #available(iOS 8.0, *) {
+            if CLLocationManager.locationServicesEnabled() {
+                self.locationManager?.stopUpdatingLocation()
+            }
+        }
+    }
+    
+    func startCompass() {
+        if #available(iOS 8.0, *) {
+            if CLLocationManager.locationServicesEnabled() {
+                self.locationManager?.startUpdatingHeading()
+            }
+        }
+    }
+    
+    func stopCompass() {
+        if #available(iOS 8.0, *) {
+            if CLLocationManager.locationServicesEnabled() {
+                self.locationManager?.stopUpdatingHeading()
+            }
+        }
+    }
+}

--- a/ZIGSIMPlus/PresenterFactory.swift
+++ b/ZIGSIMPlus/PresenterFactory.swift
@@ -22,6 +22,8 @@ class PresenterFactory {
         presenter.mediator = mediator
         presenter.commands.append(MotionMonitoringCommand())
         presenter.commands.append(BatteryMonitoringCommand())
+        presenter.commands.append(CompassMonitoringCommand())
+        presenter.commands.append(GpsMonitoringCommand())
         return presenter
     }
 }


### PR DESCRIPTION
GPSとCOMPASSコマンドを追加しました。
## 出力値
- GPS
latitude
longitude

- COMPASS
compass
faceup（スマホの向き）

## 補足
- これらのコマンドはCLLocationManagerを使用しているので、一つのブランチに入れました。
- 天城さんが実装されたBeaconコマンドもCLLocationManagerを使用しているので、今後GpsCompassDataは以下にマージする予定です。
https://github.com/1-10/ZIGSIMPlus_iOS_Public/blob/beacon/ZIGSIMPlus/Models/LocationDataStore.swift
- COMPASSの出力値faceupは、設定画面で設定した値を出力するので、設定画面作成後に追加します。

## Screenshot
![gpscompass](https://user-images.githubusercontent.com/44634617/58161869-0882da80-7cbc-11e9-989f-9ec90eb0db78.gif)
