### PR TITLE
Reuse TCP/UDP sockets 

### DIFF
--- a/ZIGSIMPlus/Models/NetworkAdapter.swift
+++ b/ZIGSIMPlus/Models/NetworkAdapter.swift
@@ -8,12 +8,15 @@
 
 import Foundation
 import SwiftSocket
-import SwiftOSC
 import CoreMotion
 
 /// Wrapper of SwiftSocket.
 public class NetworkAdapter {
     static let shared = NetworkAdapter()
+    private init() {}
+
+    var tcpClient: TCPClient = TCPClient(address: AppSettingModel.shared.address, port: AppSettingModel.shared.port)
+    var udpClient: UDPClient = UDPClient(address: AppSettingModel.shared.address, port: AppSettingModel.shared.port)
     
     /// Send data over TCP / UDP automatically
     func send(_ data: Data){
@@ -27,30 +30,47 @@ public class NetworkAdapter {
 
     private func sendTCP(_ data: Data) {
         let appSetting = AppSettingModel.shared
-        let client = TCPClient(address: appSetting.address, port: appSetting.port) // TODO: Save client to the instance
-        switch client.connect(timeout: 1) {
-        case .success:
-            switch client.send(data: data) {
+
+        // Recreate client
+        if tcpClient.address != appSetting.address || tcpClient.port != appSetting.port {
+            tcpClient.close()
+            tcpClient = TCPClient(address: appSetting.address, port: appSetting.port)
+        }
+
+        // Reopen connection if needed
+        if tcpClient.fd == nil {
+            switch tcpClient.connect(timeout: 1) {
             case .success:
-                print(">> TCP sending data succeeded")
+                print(">> TCP connection succeeded")
             case .failure(let error):
-                print(">> TCP sending data failed: \(error.localizedDescription)")
+                print(">> TCP connection failed: \(error.localizedDescription)")
+                return
             }
-            client.close()
+        }
+
+        // Send data
+        switch tcpClient.send(data: data) {
+        case .success:
+            print(">> TCP sending data succeeded")
         case .failure(let error):
-            print(">> TCP connection failed: \(error.localizedDescription)")
+            print(">> TCP sending data failed: \(error.localizedDescription)")
         }
     }
-    
+
     private func sendUDP(_ data: Data) {
         let appSetting = AppSettingModel.shared
-        let client = UDPClient(address: appSetting.address, port: appSetting.port) // TODO: Save client to the instance
-        switch client.send(data: data) {
+
+        // Recreate client
+        if udpClient.fd == nil || udpClient.address != appSetting.address || udpClient.port != appSetting.port {
+            udpClient.close()
+            udpClient = UDPClient(address: appSetting.address, port: appSetting.port)
+        }
+
+        switch udpClient.send(data: data) {
         case .success:
             print(">> UDP sending data succeeded")
         case .failure(let error):
             print(">> UDP sending data failed: \(error.localizedDescription)")
         }
-        client.close()
     }
 }

--- a/ZIGSIMPlus/Models/NetworkAdapter.swift
+++ b/ZIGSIMPlus/Models/NetworkAdapter.swift
@@ -53,7 +53,7 @@ public class NetworkAdapter {
         case .success:
             print(">> TCP sending data succeeded")
         case .failure(let error):
-            print(">> TCP sending data failed: \(error.localizedDescription)")
+            showError(error)
         }
     }
 
@@ -70,7 +70,22 @@ public class NetworkAdapter {
         case .success:
             print(">> UDP sending data succeeded")
         case .failure(let error):
-            print(">> UDP sending data failed: \(error.localizedDescription)")
+            showError(error)
+        }
+    }
+
+    private func showError(_ error: Error) {
+        switch error {
+        case SocketError.queryFailed:
+            print(">> Socket Error: Host \(AppSettingModel.shared.address) not found")
+        case SocketError.connectionClosed:
+            print(">> Socket Error: Connection is closed")
+        case SocketError.connectionTimeout:
+            print(">> Socket Error: Connection timed out")
+        case SocketError.unknownError:
+            print(">> Socket Error: Unknown socket error")
+        default:
+            print(">> Socket Error: Unknown error")
         }
     }
 }


### PR DESCRIPTION
Curretly `NetworkAdapter` create TCP/UDP clients, opens new connection, and closes them everytime `.send()` is called.
With this PR, `NetworkAdapter` will reuse TCP/UDP sockets while the setting are not changed.