### PR TITLE
Implement Apple Pencil monitoring

### DIFF
--- a/ZIGSIMPlus/Entities/LabelConstants.swift
+++ b/ZIGSIMPlus/Entities/LabelConstants.swift
@@ -22,6 +22,7 @@ public enum Label: String {
     case micLevel = "MIC LEVEL"
     case battery = "Battery"
     case ndi = "NDI"
+    case applePencil = "Apple Pencil"
 }
 
 public let CommandDataLabels = [
@@ -37,5 +38,6 @@ public let CommandDataLabels = [
     Label.proximity,
     Label.micLevel,
     Label.battery,
-    Label.ndi
+    Label.ndi,
+    Label.applePencil
 ]

--- a/ZIGSIMPlus/Models/CommandAndCommandDataMediator.swift
+++ b/ZIGSIMPlus/Models/CommandAndCommandDataMediator.swift
@@ -30,7 +30,7 @@ public class CommandAndCommandDataMediator {
         switch commandDataLabel {
         case .acceleration, .gravity, .gyro, .quaternion:
             return getCommand(by: MotionMonitoringCommand.self)
-        case .touch:
+        case .touch, .applePencil:
             return getCommand(by: TouchMonitoringCommand.self)
         case .battery:
             return getCommand(by: BatteryMonitoringCommand.self)
@@ -77,7 +77,10 @@ public class CommandAndCommandDataMediator {
         case is BeaconMonitoringCommand:
             return isCommandDataActive(Label.beacon)
         case is TouchMonitoringCommand:
-            return isCommandDataActive(Label.touch)
+            return (
+                isCommandDataActive(Label.touch) ||
+                isCommandDataActive(Label.applePencil)
+            )
         case is CompassMonitoringCommand:
             return isCommandDataActive(Label.compass)
         case is AltimeterMonitoringCommand:

--- a/ZIGSIMPlus/Models/Commands/TouchMonitoringCommand.swift
+++ b/ZIGSIMPlus/Models/Commands/TouchMonitoringCommand.swift
@@ -15,31 +15,49 @@ public final class TouchMonitoringCommand: AutoUpdatedCommand {
     
     public func start(completion: ((String?) -> Void)?) {
         TouchDataStore.shared.callback = { (touches) in
+            
+            guard let isTouchActive = AppSettingModel.shared.isActiveByCommandData[Label.touch],
+                let isApplePencilActive = AppSettingModel.shared.isActiveByCommandData[Label.applePencil]
+                else {
+                    fatalError("AppSetting of the CommandData nil")
+            }
+            
             var stringMsg = ""
             
             for touch in touches {
                 var point = touch.location(in: touch.view!)
                 point = Utils.remapToScreenCoord(point)
 
-                // Position
-                stringMsg += """
-                touch:x:\(point.x)
-                touch:y:\(point.y)
-                
-                """
-                
-                // touch radius
-                if #available(iOS 8.0, *) {
-                    stringMsg += "touch:radius:\(touch.majorRadius)\n"
-                } else {
-                    // Fallback on earlier versions
+                if isTouchActive {
+                    // Position
+                    stringMsg += """
+                    touch:x:\(point.x)
+                    touch:y:\(point.y)
+                    
+                    """
+                    
+                    // touch radius
+                    if #available(iOS 8.0, *) {
+                        stringMsg += "touch:radius:\(touch.majorRadius)\n"
+                    } else {
+                        // Fallback on earlier versions
+                    }
+                    
+                    // 3d touch
+                    if #available(iOS 9.0, *) {
+                        stringMsg += "touch:force:\(touch.force)\n"
+                    } else {
+                        // Fallback on earlier versions
+                    }
                 }
                 
-                // 3d touch
-                if #available(iOS 9.0, *) {
-                    stringMsg += "touch:force:\(touch.force)\n"
-                } else {
-                    // Fallback on earlier versions
+                if isApplePencilActive && touch.type == .pencil {
+                    stringMsg += """
+                    pencil:touch:x:\(point.x)
+                    pencil:touch:y:\(point.y)
+                    pencil:altitude:\(touch.altitudeAngle)
+                    pencil:force:\(touch.force)
+                    """
                 }
             }
             

--- a/ZIGSIMPlus/Models/Commands/TouchMonitoringCommand.swift
+++ b/ZIGSIMPlus/Models/Commands/TouchMonitoringCommand.swift
@@ -56,6 +56,7 @@ public final class TouchMonitoringCommand: AutoUpdatedCommand {
                     pencil:touch:x:\(point.x)
                     pencil:touch:y:\(point.y)
                     pencil:altitude:\(touch.altitudeAngle)
+                    pencil:azimuth:\(touch.azimuthAngle(in: touch.view!))
                     pencil:force:\(touch.force)
                     """
                 }

--- a/ZIGSIMPlus/Models/Commands/TouchMonitoringCommand.swift
+++ b/ZIGSIMPlus/Models/Commands/TouchMonitoringCommand.swift
@@ -16,22 +16,20 @@ public final class TouchMonitoringCommand: AutoUpdatedCommand {
     
     public func start(completion: ((String?) -> Void)?) {
         TouchDataStore.shared.callback = { (touches) in
-            
-            guard let isTouchActive = AppSettingModel.shared.isActiveByCommandData[Label.touch],
-                let isApplePencilActive = AppSettingModel.shared.isActiveByCommandData[Label.applePencil]
-                else {
-                    fatalError("AppSetting of the CommandData nil")
-            }
-            
-            let result = self.getTouchResult(from: touches, isTouchActive: isTouchActive, isApplePencilActive: isApplePencilActive)
+            let result = self.getTouchResult(from: touches)
             completion?(result)
         }
         
         TouchDataStore.shared.enable()
     }
     
-    private func getTouchResult(from touches:[UITouch], isTouchActive: Bool, isApplePencilActive: Bool) -> String {
-        
+    private func getTouchResult(from touches:[UITouch]) -> String {
+        guard let isTouchActive = AppSettingModel.shared.isActiveByCommandData[Label.touch],
+            let isApplePencilActive = AppSettingModel.shared.isActiveByCommandData[Label.applePencil]
+            else {
+                fatalError("AppSetting of the CommandData nil")
+        }
+
         var result = ""
         for touch in touches {
             var point = touch.location(in: touch.view!)

--- a/ZIGSIMPlus/Models/Commands/TouchMonitoringCommand.swift
+++ b/ZIGSIMPlus/Models/Commands/TouchMonitoringCommand.swift
@@ -22,7 +22,7 @@ public final class TouchMonitoringCommand: AutoUpdatedCommand {
                     fatalError("AppSetting of the CommandData nil")
             }
             
-            var stringMsg = ""
+            var result = ""
             
             for touch in touches {
                 var point = touch.location(in: touch.view!)
@@ -30,39 +30,34 @@ public final class TouchMonitoringCommand: AutoUpdatedCommand {
 
                 if isTouchActive {
                     // Position
-                    stringMsg += """
+                    result.appendLines("""
                     touch:x:\(point.x)
                     touch:y:\(point.y)
-                    
-                    """
+                    """)
                     
                     // touch radius
                     if #available(iOS 8.0, *) {
-                        stringMsg += "touch:radius:\(touch.majorRadius)\n"
-                    } else {
-                        // Fallback on earlier versions
+                        result.appendLines("touch:radius:\(touch.majorRadius)")
                     }
                     
                     // 3d touch
                     if #available(iOS 9.0, *) {
-                        stringMsg += "touch:force:\(touch.force)\n"
-                    } else {
-                        // Fallback on earlier versions
+                        result.appendLines("touch:force:\(touch.force)")
                     }
                 }
                 
                 if isApplePencilActive && touch.type == .pencil {
-                    stringMsg += """
+                    result.appendLines("""
                     pencil:touch:x:\(point.x)
                     pencil:touch:y:\(point.y)
                     pencil:altitude:\(touch.altitudeAngle)
                     pencil:azimuth:\(touch.azimuthAngle(in: touch.view!))
                     pencil:force:\(touch.force)
-                    """
+                    """)
                 }
             }
             
-            completion?(stringMsg)
+            completion?(result)
         }
         
         TouchDataStore.shared.enable()

--- a/ZIGSIMPlus/Models/Stores/TouchDataStore.swift
+++ b/ZIGSIMPlus/Models/Stores/TouchDataStore.swift
@@ -88,7 +88,13 @@ public class TouchDataStore {
 
 extension TouchDataStore : Store {
     func toOSC() -> [OSCMessage] {
-        if !AppSettingModel.shared.isActiveByCommandData[Label.touch]! {
+        guard let isTouchActive = AppSettingModel.shared.isActiveByCommandData[Label.touch],
+            let isApplePencilActive = AppSettingModel.shared.isActiveByCommandData[Label.applePencil]
+            else {
+                fatalError("AppSetting of the CommandData nil")
+        }
+        
+        if !isTouchActive && !isApplePencilActive {
             return []
         }
         
@@ -99,15 +105,25 @@ extension TouchDataStore : Store {
             var point = touch.location(in: touch.view!)
             point = Utils.remapToScreenCoord(point)
 
-            // Position
-            messages.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/touch\(i)1"), Float(point.x)))
-            messages.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/touch\(i)2"), Float(point.y)))
+            if isTouchActive {
+                // Position
+                messages.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/touch\(i)1"), Float(point.x)))
+                messages.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/touch\(i)2"), Float(point.y)))
 
-            if #available(iOS 8.0, *) {
-                messages.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/touchradius\(i)"), Float(touch.majorRadius)))
+                if #available(iOS 8.0, *) {
+                    messages.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/touchradius\(i)"), Float(touch.majorRadius)))
+                }
+                if #available(iOS 9.0, *) {
+                    messages.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/touchforce\(i)"), Float(touch.force)))
+                }
             }
-            if #available(iOS 9.0, *) {
-                messages.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/touchforce\(i)"), Float(touch.force)))
+            
+            if isApplePencilActive && touch.type == .pencil {
+                messages.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/penciltouch\(i)1"), Float(point.x)))
+                messages.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/penciltouch\(i)2"), Float(point.y)))
+                messages.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/pencilaltitude\(i)"), Float(touch.altitudeAngle)))
+                messages.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/pencilazimuth\(i)"), Float(touch.azimuthAngle(in: touch.view!))))
+                messages.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/pencilforce\(i)"), Float(touch.force)))
             }
         }
         
@@ -115,25 +131,51 @@ extension TouchDataStore : Store {
     }
     
     func toJSON() -> [String:AnyObject] {
-        if !AppSettingModel.shared.isActiveByCommandData[Label.touch]! {
+        guard let isTouchActive = AppSettingModel.shared.isActiveByCommandData[Label.touch],
+            let isApplePencilActive = AppSettingModel.shared.isActiveByCommandData[Label.applePencil]
+            else {
+                fatalError("AppSetting of the CommandData nil")
+        }
+        
+        if !isTouchActive && !isApplePencilActive {
             return [:]
         }
         
-        let objs: [Dictionary<String, CGFloat>] = touchPoints.map { touch in
-            var point = touch.location(in: touch.view!)
-            point = Utils.remapToScreenCoord(point)
+        var data = [String:AnyObject]()
+        if isTouchActive {
+            let touchData: [Dictionary<String, CGFloat>] = touchPoints.map { touch in
+                var point = touch.location(in: touch.view!)
+                point = Utils.remapToScreenCoord(point)
 
-            var obj = ["x": point.x, "y": point.y]
-            
-            if #available(iOS 8.0, *) {
-                obj["radius"] = touch.majorRadius
+                var obj = ["x": point.x, "y": point.y]
+                
+                if #available(iOS 8.0, *) {
+                    obj["radius"] = touch.majorRadius
+                }
+                if #available(iOS 9.0, *) {
+                    obj["force"] = touch.force
+                }
+                
+                return obj
             }
-            if #available(iOS 9.0, *) {
-                obj["force"] = touch.force
-            }
-            
-            return obj
+            data.merge(["touches": touchData as AnyObject]) { $1 }
         }
-        return ["touches": objs as AnyObject]
+        
+        if isApplePencilActive {
+            let pencilData: [Dictionary<String, CGFloat>] = touchPoints.map { touch in
+                var point = touch.location(in: touch.view!)
+                point = Utils.remapToScreenCoord(point)
+                
+                return ["x": point.x,
+                        "y": point.y,
+                        "altitude": touch.altitudeAngle,
+                        "azimuth": touch.azimuthAngle(in: touch.view!),
+                        "force": touch.force
+                        ]
+            }
+            data.merge(["pencil": pencilData as AnyObject]) { $1 }
+        }
+        
+        return data
     }
 }


### PR DESCRIPTION
# Changes
- Add "Apple Pencil" to `Label`
- Use `TouchMonitoringCommand` to monitor Apple Pencil

# Note
- Currently, output order of Apple Pencil is next to Touch.
  It's a future task to order output by Command Data (currently it's ordered by Command).
- Currently, Apple Pencil command data is always available.
  To implement a strict check, it's necessary to update `Command` protocol and all `Commands'` `isAvailable()` method.
  I'm leaving it as a future task.

# Test
I tested on iPad 6th Gen and iPhone 7.
I haven't tested OSC or JSON data, it should be done by test code.