### PR TITLE
Fix Touch Bug

### DIFF
--- a/ZIGSIMPlus.xcodeproj/project.pbxproj
+++ b/ZIGSIMPlus.xcodeproj/project.pbxproj
@@ -366,8 +366,8 @@
 			isa = PBXGroup;
 			children = (
 				902EB9F9227BED1B008F1650 /* CommandSelectionPresenter.swift */,
-				02621F5822A4F9250071E9D2 /* CommandSettingPresenter.swift */,
 				9092E4D0227ECCFA0019F1C1 /* CommandOutputPresenter.swift */,
+				02621F5822A4F9250071E9D2 /* CommandSettingPresenter.swift */,
 			);
 			path = Presenters;
 			sourceTree = "<group>";

--- a/ZIGSIMPlus/Presenters/CommandOutputPresenter.swift
+++ b/ZIGSIMPlus/Presenters/CommandOutputPresenter.swift
@@ -58,7 +58,6 @@ final class CommandOutputPresenter: CommandOutputPresenterProtocol {
         }
 
         mediator.stopActiveCommands()
-        ServiceManager.shared.send()
     }
     
     


### PR DESCRIPTION
This error occurs when switching from output screen to selection screen.

```
Thread 1: Fatal error: Unexpectedly found nil while unwrapping an Optional value
TouchService.swift line 148
```

To avoid this and keep consistency with other commands, I removed `ServiceManager.shared.send()` in `CommandOutputPresenter.stopCommands()`.