### PR TITLE
Fix touch position range / Show device settings in Output tab

### DIFF
--- a/ZIGSIMPlus.xcodeproj/project.pbxproj
+++ b/ZIGSIMPlus.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		02621F5922A4F9250071E9D2 /* CommandSettingPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02621F5822A4F9250071E9D2 /* CommandSettingPresenter.swift */; };
 		0274B66322A0FD00005D7266 /* RemoteControlService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0274B66222A0FD00005D7266 /* RemoteControlService.swift */; };
 		0281B29722A6791500ED97D9 /* ServiceManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0281B29622A6791500ED97D9 /* ServiceManagerTests.swift */; };
+		0296D23C22AA4E1C00EDD3F8 /* CommandOutputViewSettingsTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0296D23B22AA4E1C00EDD3F8 /* CommandOutputViewSettingsTableCell.swift */; };
 		02A03597229CD56E00E7399E /* AltimeterService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A03594229CD56D00E7399E /* AltimeterService.swift */; };
 		02A03598229CD56E00E7399E /* AudioLevelService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A03595229CD56E00E7399E /* AudioLevelService.swift */; };
 		02A03599229CD56E00E7399E /* ProximityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A03596229CD56E00E7399E /* ProximityService.swift */; };
@@ -100,6 +101,7 @@
 		02621F5822A4F9250071E9D2 /* CommandSettingPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandSettingPresenter.swift; sourceTree = "<group>"; };
 		0274B66222A0FD00005D7266 /* RemoteControlService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteControlService.swift; sourceTree = "<group>"; };
 		0281B29622A6791500ED97D9 /* ServiceManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServiceManagerTests.swift; sourceTree = "<group>"; };
+		0296D23B22AA4E1C00EDD3F8 /* CommandOutputViewSettingsTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandOutputViewSettingsTableCell.swift; sourceTree = "<group>"; };
 		02A03594229CD56D00E7399E /* AltimeterService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AltimeterService.swift; sourceTree = "<group>"; };
 		02A03595229CD56E00E7399E /* AudioLevelService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioLevelService.swift; sourceTree = "<group>"; };
 		02A03596229CD56E00E7399E /* ProximityService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProximityService.swift; sourceTree = "<group>"; };
@@ -378,6 +380,7 @@
 				902EB9CB227BE68D008F1650 /* CommandSelectionViewController.swift */,
 				9092E4C9227D8ADF0019F1C1 /* CommandOutputViewController.swift */,
 				02A0359A229CD6F800E7399E /* CommandSettingViewController.swift */,
+				0296D23B22AA4E1C00EDD3F8 /* CommandOutputViewSettingsTableCell.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -671,6 +674,7 @@
 				9092E4CC227EBF4D0019F1C1 /* Command.swift in Sources */,
 				903BA771227D6C2100A2C378 /* AppSettingModel.swift in Sources */,
 				02621F5522A4F9140071E9D2 /* UITextFieldExtension.swift in Sources */,
+				0296D23C22AA4E1C00EDD3F8 /* CommandOutputViewSettingsTableCell.swift in Sources */,
 				9092E4D1227ECCFA0019F1C1 /* CommandOutputPresenter.swift in Sources */,
 				02F0DBF3229FC2EA00D45E56 /* ArkitService.swift in Sources */,
 				02A03599229CD56E00E7399E /* ProximityService.swift in Sources */,

--- a/ZIGSIMPlus/Base.lproj/Main.storyboard
+++ b/ZIGSIMPlus/Base.lproj/Main.storyboard
@@ -459,20 +459,53 @@
                                     <segue destination="DBP-kb-Ioh" kind="embed" id="GEr-8N-jeF"/>
                                 </connections>
                             </containerView>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="40" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="pRt-3u-oEi" userLabel="Settings Table">
-                                <rect key="frame" x="16" y="44" width="382" height="200"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="30" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="pRt-3u-oEi" userLabel="Settings Table">
+                                <rect key="frame" x="16" y="52" width="382" height="150"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="200" id="EX4-pP-biJ"/>
+                                    <constraint firstAttribute="height" constant="150" id="EX4-pP-biJ"/>
                                 </constraints>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SettingCell" id="hIK-hM-KsR" userLabel="SettingCell">
-                                        <rect key="frame" x="0.0" y="28" width="382" height="40"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SettingCell" id="hIK-hM-KsR" userLabel="SettingCell" customClass="CommandOutputViewSettingsTableCell" customModule="ZIGSIMPlus" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="28" width="382" height="30"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="hIK-hM-KsR" id="HKm-9W-xZe">
-                                            <rect key="frame" x="0.0" y="0.0" width="382" height="39.666666666666664"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="382" height="30"/>
                                             <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="74Q-2M-xNe" userLabel="SettingKey">
+                                                    <rect key="frame" x="0.0" y="0.0" width="150" height="20"/>
+                                                    <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="150" id="NhB-lG-oNC"/>
+                                                        <constraint firstAttribute="height" constant="20" id="kr2-rH-8Da"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
+                                                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kds-WB-sXb" userLabel="SettingValue">
+                                                    <rect key="frame" x="158" y="0.0" width="224" height="20"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="20" id="9S5-TK-1jh"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" secondItem="Kds-WB-sXb" secondAttribute="trailing" id="ElP-De-zPx"/>
+                                                <constraint firstItem="Kds-WB-sXb" firstAttribute="top" secondItem="HKm-9W-xZe" secondAttribute="top" id="J8I-6i-g3B"/>
+                                                <constraint firstItem="74Q-2M-xNe" firstAttribute="leading" secondItem="HKm-9W-xZe" secondAttribute="leading" id="Ojc-cj-EDH"/>
+                                                <constraint firstItem="74Q-2M-xNe" firstAttribute="top" secondItem="HKm-9W-xZe" secondAttribute="top" id="bPu-3B-07o"/>
+                                                <constraint firstItem="Kds-WB-sXb" firstAttribute="leading" secondItem="74Q-2M-xNe" secondAttribute="trailing" constant="8" id="uk5-hE-rn3"/>
+                                                <constraint firstItem="74Q-2M-xNe" firstAttribute="leading" secondItem="HKm-9W-xZe" secondAttribute="leading" id="uzL-TW-ilO"/>
+                                            </constraints>
                                         </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="settingKeyLabel" destination="74Q-2M-xNe" id="5t6-i0-CPp"/>
+                                            <outlet property="settingValueLabel" destination="Kds-WB-sXb" id="F1x-AO-bkM"/>
+                                        </connections>
                                     </tableViewCell>
                                 </prototypes>
                                 <connections>
@@ -481,7 +514,7 @@
                                 </connections>
                             </tableView>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="w9T-O2-Ptu">
-                                <rect key="frame" x="16" y="244" width="382" height="569"/>
+                                <rect key="frame" x="16" y="202" width="382" height="611"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <accessibility key="accessibilityConfiguration">
                                     <accessibilityTraits key="traits" notEnabled="YES"/>
@@ -503,7 +536,7 @@
                             <constraint firstItem="VFr-by-ckd" firstAttribute="bottom" secondItem="wNG-or-TOh" secondAttribute="bottom" id="BR2-iH-vbf"/>
                             <constraint firstItem="QnG-HF-yg8" firstAttribute="leading" secondItem="wNG-or-TOh" secondAttribute="leading" constant="16" id="MWN-kY-KmV"/>
                             <constraint firstItem="VFr-by-ckd" firstAttribute="top" secondItem="wNG-or-TOh" secondAttribute="top" id="Twj-MF-agV"/>
-                            <constraint firstItem="pRt-3u-oEi" firstAttribute="top" secondItem="wNG-or-TOh" secondAttribute="top" id="V3Z-9S-xZ0"/>
+                            <constraint firstItem="pRt-3u-oEi" firstAttribute="top" secondItem="wNG-or-TOh" secondAttribute="top" constant="8" id="V3Z-9S-xZ0"/>
                             <constraint firstItem="QnG-HF-yg8" firstAttribute="bottom" secondItem="wNG-or-TOh" secondAttribute="bottom" id="W3Y-hN-XCI"/>
                             <constraint firstItem="w9T-O2-Ptu" firstAttribute="top" secondItem="pRt-3u-oEi" secondAttribute="bottom" id="Zl1-Td-v4b"/>
                             <constraint firstItem="w9T-O2-Ptu" firstAttribute="bottom" secondItem="wNG-or-TOh" secondAttribute="bottom" id="dET-yb-enz"/>

--- a/ZIGSIMPlus/Base.lproj/Main.storyboard
+++ b/ZIGSIMPlus/Base.lproj/Main.storyboard
@@ -550,6 +550,7 @@
                     </view>
                     <tabBarItem key="tabBarItem" tag="2" title="Output" id="ZJH-dY-5eg"/>
                     <connections>
+                        <outlet property="settingsTable" destination="pRt-3u-oEi" id="HZQ-Jq-U9s"/>
                         <outlet property="textField" destination="w9T-O2-Ptu" id="SBs-k4-5Vg"/>
                         <outlet property="touchArea" destination="VFr-by-ckd" id="xXl-zN-frG"/>
                     </connections>

--- a/ZIGSIMPlus/Base.lproj/Main.storyboard
+++ b/ZIGSIMPlus/Base.lproj/Main.storyboard
@@ -460,10 +460,10 @@
                                 </connections>
                             </containerView>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="30" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="pRt-3u-oEi" userLabel="Settings Table">
-                                <rect key="frame" x="16" y="52" width="382" height="150"/>
+                                <rect key="frame" x="16" y="52" width="382" height="180"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="150" id="EX4-pP-biJ"/>
+                                    <constraint firstAttribute="height" constant="180" id="EX4-pP-biJ"/>
                                 </constraints>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SettingCell" id="hIK-hM-KsR" userLabel="SettingCell" customClass="CommandOutputViewSettingsTableCell" customModule="ZIGSIMPlus" customModuleProvider="target">
@@ -514,7 +514,7 @@
                                 </connections>
                             </tableView>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="w9T-O2-Ptu">
-                                <rect key="frame" x="16" y="202" width="382" height="611"/>
+                                <rect key="frame" x="16" y="232" width="382" height="581"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <accessibility key="accessibilityConfiguration">
                                     <accessibilityTraits key="traits" notEnabled="YES"/>

--- a/ZIGSIMPlus/Base.lproj/Main.storyboard
+++ b/ZIGSIMPlus/Base.lproj/Main.storyboard
@@ -470,18 +470,21 @@
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
-                            <view multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VFr-by-ckd" userLabel="Touch Area">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
-                                <autoresizingMask key="autoresizingMask"/>
+                            <view multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VFr-by-ckd" userLabel="Touch Area">
+                                <rect key="frame" x="16" y="44" width="382" height="769"/>
                             </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="w9T-O2-Ptu" firstAttribute="leading" secondItem="wNG-or-TOh" secondAttribute="leading" constant="16" id="4kM-Wz-6he"/>
+                            <constraint firstItem="VFr-by-ckd" firstAttribute="leading" secondItem="wNG-or-TOh" secondAttribute="leading" constant="16" id="AzF-iW-5IK"/>
+                            <constraint firstItem="VFr-by-ckd" firstAttribute="bottom" secondItem="wNG-or-TOh" secondAttribute="bottom" id="BR2-iH-vbf"/>
                             <constraint firstItem="QnG-HF-yg8" firstAttribute="leading" secondItem="wNG-or-TOh" secondAttribute="leading" constant="16" id="MWN-kY-KmV"/>
+                            <constraint firstItem="VFr-by-ckd" firstAttribute="top" secondItem="wNG-or-TOh" secondAttribute="top" id="Twj-MF-agV"/>
                             <constraint firstItem="QnG-HF-yg8" firstAttribute="bottom" secondItem="wNG-or-TOh" secondAttribute="bottom" id="W3Y-hN-XCI"/>
                             <constraint firstItem="w9T-O2-Ptu" firstAttribute="top" secondItem="wNG-or-TOh" secondAttribute="top" id="cb3-hL-JhH"/>
                             <constraint firstItem="w9T-O2-Ptu" firstAttribute="bottom" secondItem="wNG-or-TOh" secondAttribute="bottom" id="dET-yb-enz"/>
+                            <constraint firstItem="wNG-or-TOh" firstAttribute="trailing" secondItem="VFr-by-ckd" secondAttribute="trailing" constant="16" id="qoH-lr-QDv"/>
                             <constraint firstItem="wNG-or-TOh" firstAttribute="trailing" secondItem="QnG-HF-yg8" secondAttribute="trailing" constant="16" id="rt4-cR-bFh"/>
                             <constraint firstItem="wNG-or-TOh" firstAttribute="trailing" secondItem="w9T-O2-Ptu" secondAttribute="trailing" constant="16" id="w3E-bs-oOu"/>
                             <constraint firstItem="QnG-HF-yg8" firstAttribute="top" secondItem="wNG-or-TOh" secondAttribute="top" id="wEm-aa-Mk3"/>
@@ -491,11 +494,12 @@
                     <tabBarItem key="tabBarItem" tag="2" title="Output" id="ZJH-dY-5eg"/>
                     <connections>
                         <outlet property="textField" destination="w9T-O2-Ptu" id="SBs-k4-5Vg"/>
+                        <outlet property="touchArea" destination="VFr-by-ckd" id="xXl-zN-frG"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="cTa-iw-AJe" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1075" y="913"/>
+            <point key="canvasLocation" x="1073.913043478261" y="912.72321428571422"/>
         </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="4iF-GW-zpL">

--- a/ZIGSIMPlus/Base.lproj/Main.storyboard
+++ b/ZIGSIMPlus/Base.lproj/Main.storyboard
@@ -459,8 +459,29 @@
                                     <segue destination="DBP-kb-Ioh" kind="embed" id="GEr-8N-jeF"/>
                                 </connections>
                             </containerView>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="40" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="pRt-3u-oEi" userLabel="Settings Table">
+                                <rect key="frame" x="16" y="44" width="382" height="200"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="200" id="EX4-pP-biJ"/>
+                                </constraints>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SettingCell" id="hIK-hM-KsR" userLabel="SettingCell">
+                                        <rect key="frame" x="0.0" y="28" width="382" height="40"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="hIK-hM-KsR" id="HKm-9W-xZe">
+                                            <rect key="frame" x="0.0" y="0.0" width="382" height="39.666666666666664"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                                <connections>
+                                    <outlet property="dataSource" destination="AD7-px-bC2" id="R4t-2t-eVZ"/>
+                                    <outlet property="delegate" destination="AD7-px-bC2" id="8eQ-W4-eH2"/>
+                                </connections>
+                            </tableView>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="w9T-O2-Ptu">
-                                <rect key="frame" x="16" y="44" width="382" height="769"/>
+                                <rect key="frame" x="16" y="244" width="382" height="569"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <accessibility key="accessibilityConfiguration">
                                     <accessibilityTraits key="traits" notEnabled="YES"/>
@@ -476,14 +497,17 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
+                            <constraint firstItem="wNG-or-TOh" firstAttribute="trailing" secondItem="pRt-3u-oEi" secondAttribute="trailing" constant="16" id="1Ac-Qa-hwQ"/>
                             <constraint firstItem="w9T-O2-Ptu" firstAttribute="leading" secondItem="wNG-or-TOh" secondAttribute="leading" constant="16" id="4kM-Wz-6he"/>
                             <constraint firstItem="VFr-by-ckd" firstAttribute="leading" secondItem="wNG-or-TOh" secondAttribute="leading" constant="16" id="AzF-iW-5IK"/>
                             <constraint firstItem="VFr-by-ckd" firstAttribute="bottom" secondItem="wNG-or-TOh" secondAttribute="bottom" id="BR2-iH-vbf"/>
                             <constraint firstItem="QnG-HF-yg8" firstAttribute="leading" secondItem="wNG-or-TOh" secondAttribute="leading" constant="16" id="MWN-kY-KmV"/>
                             <constraint firstItem="VFr-by-ckd" firstAttribute="top" secondItem="wNG-or-TOh" secondAttribute="top" id="Twj-MF-agV"/>
+                            <constraint firstItem="pRt-3u-oEi" firstAttribute="top" secondItem="wNG-or-TOh" secondAttribute="top" id="V3Z-9S-xZ0"/>
                             <constraint firstItem="QnG-HF-yg8" firstAttribute="bottom" secondItem="wNG-or-TOh" secondAttribute="bottom" id="W3Y-hN-XCI"/>
-                            <constraint firstItem="w9T-O2-Ptu" firstAttribute="top" secondItem="wNG-or-TOh" secondAttribute="top" id="cb3-hL-JhH"/>
+                            <constraint firstItem="w9T-O2-Ptu" firstAttribute="top" secondItem="pRt-3u-oEi" secondAttribute="bottom" id="Zl1-Td-v4b"/>
                             <constraint firstItem="w9T-O2-Ptu" firstAttribute="bottom" secondItem="wNG-or-TOh" secondAttribute="bottom" id="dET-yb-enz"/>
+                            <constraint firstItem="pRt-3u-oEi" firstAttribute="leading" secondItem="wNG-or-TOh" secondAttribute="leading" constant="16" id="nmw-Mg-E1r"/>
                             <constraint firstItem="wNG-or-TOh" firstAttribute="trailing" secondItem="VFr-by-ckd" secondAttribute="trailing" constant="16" id="qoH-lr-QDv"/>
                             <constraint firstItem="wNG-or-TOh" firstAttribute="trailing" secondItem="QnG-HF-yg8" secondAttribute="trailing" constant="16" id="rt4-cR-bFh"/>
                             <constraint firstItem="wNG-or-TOh" firstAttribute="trailing" secondItem="w9T-O2-Ptu" secondAttribute="trailing" constant="16" id="w3E-bs-oOu"/>

--- a/ZIGSIMPlus/Models/AppSettingModel.swift
+++ b/ZIGSIMPlus/Models/AppSettingModel.swift
@@ -73,16 +73,18 @@ public class AppSettingModel {
         return Double(faceup)
     }
 
-    public func getSettingsForOutput() -> [String:String] {
+    public func getSettingsForOutput() -> [(String, String)] {
+        let dst = dataDestination == .OTHER_APP ? "OTHER APP" : "LOCAL FILE"
         let prot = transportProtocol == .TCP ? "TCP" : "UDP"
         let format = transportFormat == .OSC ? "OSC" : "JSON"
 
         return [
-            "PROTOCOL": prot,
-            "IP ADDRESS": address,
-            "PORT": String(port),
-            "MESSAGE FORMAT": format,
-            "DEVICE UUID": deviceUUID,
+            ("DATA DESTINATION", dst),
+            ("PROTOCOL", prot),
+            ("IP ADDRESS", address),
+            ("PORT", String(port)),
+            ("MESSAGE FORMAT", format),
+            ("DEVICE UUID", deviceUUID),
         ]
     }
 }

--- a/ZIGSIMPlus/Models/AppSettingModel.swift
+++ b/ZIGSIMPlus/Models/AppSettingModel.swift
@@ -72,6 +72,19 @@ public class AppSettingModel {
     var compassAngle: Double {
         return Double(faceup)
     }
+
+    public func getSettingsForOutput() -> [String:String] {
+        let prot = transportProtocol == .TCP ? "TCP" : "UDP"
+        let format = transportFormat == .OSC ? "OSC" : "JSON"
+
+        return [
+            "PROTOCOL": prot,
+            "IP ADDRESS": address,
+            "PORT": String(port),
+            "MESSAGE FORMAT": format,
+            "DEVICE UUID": deviceUUID,
+        ]
+    }
 }
 
 // user default value

--- a/ZIGSIMPlus/Models/Utils.swift
+++ b/ZIGSIMPlus/Models/Utils.swift
@@ -35,15 +35,6 @@ class Utils {
         return UIScreen.main.bounds.height * UIScreen.main.scale
     }
 
-    // Remap values to range [-1, 1]
-    static func remapToScreenCoord(_ pos: CGPoint) -> CGPoint {
-        let bounds = UIScreen.main.bounds
-        return CGPoint(
-            x: pos.x / bounds.width * 2 - 1,
-            y: pos.y / bounds.height * 2 - 1
-        )
-    }
-    
     static func getTimestamp() -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"

--- a/ZIGSIMPlus/Presenters/CommandOutputPresenter.swift
+++ b/ZIGSIMPlus/Presenters/CommandOutputPresenter.swift
@@ -16,6 +16,7 @@ protocol CommandOutputPresenterProtocol {
 
 protocol CommandOutputPresenterDelegate: AnyObject {
     func updateOutput(with output: String)
+    func updateSettings(with settings: [String:String])
 }
 
 final class CommandOutputPresenter: CommandOutputPresenterProtocol {
@@ -40,6 +41,9 @@ final class CommandOutputPresenter: CommandOutputPresenterProtocol {
         mediator.startActiveCommands()
         ServiceManager.shared.send()
         updateOutput()
+
+        let settings = AppSettingModel.shared.getSettingsForOutput()
+        view.updateSettings(with: settings)
     }
 
     // MARK: Monitor commands

--- a/ZIGSIMPlus/Presenters/CommandOutputPresenter.swift
+++ b/ZIGSIMPlus/Presenters/CommandOutputPresenter.swift
@@ -16,7 +16,7 @@ protocol CommandOutputPresenterProtocol {
 
 protocol CommandOutputPresenterDelegate: AnyObject {
     func updateOutput(with output: String)
-    func updateSettings(with settings: [String:String])
+    func updateSettings(with settings: [(String, String)])
 }
 
 final class CommandOutputPresenter: CommandOutputPresenterProtocol {

--- a/ZIGSIMPlus/Views/CommandOutputViewController.swift
+++ b/ZIGSIMPlus/Views/CommandOutputViewController.swift
@@ -67,27 +67,7 @@ extension CommandOutputViewController: CommandOutputPresenterDelegate {
     }
 }
 
-extension CommandOutputViewController: UITableViewDelegate {
-//    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-//        if let cell = tableView.cellForRow(at: indexPath) {
-//            tableView.deselectRow(at: indexPath, animated: true)
-//            presenter.didSelectRow(atLabel: (cell.textLabel?.text)!)
-//            cell.accessoryType = (cell.accessoryType == .checkmark ? .none : .checkmark)
-//        }
-//    }
-
-    // Disallow selecting unavailable command
-//    func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
-//        if let cell = tableView.cellForRow(at: indexPath) {
-//            let ip = tableView.indexPath(for: cell)!
-//            let CommandToSelect = presenter.getCommandToSelect(forRow: ip.row)
-//            if !CommandToSelect.isAvailable {
-//                return nil
-//            }
-//        }
-//        return indexPath
-//    }
-}
+extension CommandOutputViewController: UITableViewDelegate {}
 
 extension CommandOutputViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -97,11 +77,12 @@ extension CommandOutputViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "SettingCell", for: indexPath)
 
-        let key = [String](settings.keys)[indexPath.row]
-        let value = settings[key]
+        if let c = cell as? CommandOutputViewSettingsTableCell {
+            let key = [String](settings.keys)[indexPath.row]
+            let value = settings[key]
+            c.setKeyValue(key, value)
+        }
 
-        cell.textLabel!.text = key + ":" + value!
-//        cell.isUserInteractionEnabled = CommandToSelect.isAvailable
         return cell
     }
 }

--- a/ZIGSIMPlus/Views/CommandOutputViewController.swift
+++ b/ZIGSIMPlus/Views/CommandOutputViewController.swift
@@ -11,6 +11,7 @@ import MediaPlayer
 
 class CommandOutputViewController: UIViewController {
     @IBOutlet weak var textField: UITextView!
+    @IBOutlet weak var touchArea: UIView!
 
     var presenter: CommandOutputPresenterProtocol!
 
@@ -22,8 +23,13 @@ class CommandOutputViewController: UIViewController {
         // Dummy volume view to disable default system volume hooks
         let volumeView = MPVolumeView(frame: CGRect(x: -100, y: -100, width: 0, height: 0))
         view.addSubview(volumeView)
-        
         presenter.startCommands()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        // Set area for touch points.
+        // This has to be done after auto layout.
+        TouchService.shared.setTouchArea(rect: touchArea.bounds)
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/ZIGSIMPlus/Views/CommandOutputViewController.swift
+++ b/ZIGSIMPlus/Views/CommandOutputViewController.swift
@@ -13,6 +13,8 @@ class CommandOutputViewController: UIViewController {
     @IBOutlet weak var textField: UITextView!
     @IBOutlet weak var touchArea: UIView!
 
+    var settings: [String:String] = [:]
+
     var presenter: CommandOutputPresenterProtocol!
 
     override func viewDidLoad() {
@@ -58,5 +60,48 @@ class CommandOutputViewController: UIViewController {
 extension CommandOutputViewController: CommandOutputPresenterDelegate {
     func updateOutput(with output: String) {
         textField.text = output
+    }
+
+    func updateSettings(with newSettings: [String : String]) {
+        settings = newSettings
+    }
+}
+
+extension CommandOutputViewController: UITableViewDelegate {
+//    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+//        if let cell = tableView.cellForRow(at: indexPath) {
+//            tableView.deselectRow(at: indexPath, animated: true)
+//            presenter.didSelectRow(atLabel: (cell.textLabel?.text)!)
+//            cell.accessoryType = (cell.accessoryType == .checkmark ? .none : .checkmark)
+//        }
+//    }
+
+    // Disallow selecting unavailable command
+//    func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+//        if let cell = tableView.cellForRow(at: indexPath) {
+//            let ip = tableView.indexPath(for: cell)!
+//            let CommandToSelect = presenter.getCommandToSelect(forRow: ip.row)
+//            if !CommandToSelect.isAvailable {
+//                return nil
+//            }
+//        }
+//        return indexPath
+//    }
+}
+
+extension CommandOutputViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return settings.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "SettingCell", for: indexPath)
+
+        let key = [String](settings.keys)[indexPath.row]
+        let value = settings[key]
+
+        cell.textLabel!.text = key + ":" + value!
+//        cell.isUserInteractionEnabled = CommandToSelect.isAvailable
+        return cell
     }
 }

--- a/ZIGSIMPlus/Views/CommandOutputViewController.swift
+++ b/ZIGSIMPlus/Views/CommandOutputViewController.swift
@@ -14,7 +14,7 @@ class CommandOutputViewController: UIViewController {
     @IBOutlet weak var touchArea: UIView!
 
     @IBOutlet weak var settingsTable: UITableView!
-    var settings: [String:String] = [:]
+    var settings: [(String, String)] = []
 
     var presenter: CommandOutputPresenterProtocol!
 
@@ -63,7 +63,7 @@ extension CommandOutputViewController: CommandOutputPresenterDelegate {
         textField.text = output
     }
 
-    func updateSettings(with newSettings: [String : String]) {
+    func updateSettings(with newSettings: [(String, String)]) {
         settings = newSettings
         settingsTable.reloadData()
     }
@@ -80,9 +80,8 @@ extension CommandOutputViewController: UITableViewDataSource {
         let cell = tableView.dequeueReusableCell(withIdentifier: "SettingCell", for: indexPath)
 
         if let c = cell as? CommandOutputViewSettingsTableCell {
-            let key = [String](settings.keys)[indexPath.row]
-            let value = settings[key]
-            c.setKeyValue(key, value)
+            let kv = settings[indexPath.row]
+            c.setKeyValue(kv.0, kv.1)
         }
 
         return cell

--- a/ZIGSIMPlus/Views/CommandOutputViewController.swift
+++ b/ZIGSIMPlus/Views/CommandOutputViewController.swift
@@ -13,6 +13,7 @@ class CommandOutputViewController: UIViewController {
     @IBOutlet weak var textField: UITextView!
     @IBOutlet weak var touchArea: UIView!
 
+    @IBOutlet weak var settingsTable: UITableView!
     var settings: [String:String] = [:]
 
     var presenter: CommandOutputPresenterProtocol!
@@ -64,6 +65,7 @@ extension CommandOutputViewController: CommandOutputPresenterDelegate {
 
     func updateSettings(with newSettings: [String : String]) {
         settings = newSettings
+        settingsTable.reloadData()
     }
 }
 

--- a/ZIGSIMPlus/Views/CommandOutputViewSettingsTableCell.swift
+++ b/ZIGSIMPlus/Views/CommandOutputViewSettingsTableCell.swift
@@ -1,0 +1,20 @@
+//
+//  CommandOutputViewSettingsTableCell.swift
+//  ZIGSIMPlus
+//
+//  Created by Takayosi Amagi on 2019/06/07.
+//  Copyright © 2019 Nozomu Kuwae. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+class CommandOutputViewSettingsTableCell: UITableViewCell {
+    @IBOutlet weak var settingKeyLabel: UILabel!
+    @IBOutlet weak var settingValueLabel: UILabel!
+
+    public func setKeyValue(_ key: String?, _ value: String?) {
+        settingKeyLabel.text = " \(key ?? "")" // add padding
+        settingValueLabel.text = value
+    }
+}


### PR DESCRIPTION
This PR includes 2 feature changes:

- Track touch position inside safe area
  - If touches were detected outside the safe area, the positions will be clamped to the range from (-1, -1) to (1, 1)
- Show device settings on the top of Output tab

### screenshot

![image](https://user-images.githubusercontent.com/1403842/59091752-f905c180-894a-11e9-8824-cee0adb32ddf.png)
