### PR TITLE
Keep app running for a while after going background

### DIFF
--- a/ZIGSIMPlus/AppDelegate.swift
+++ b/ZIGSIMPlus/AppDelegate.swift
@@ -12,6 +12,7 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
+    var backgroundTaskID = UIBackgroundTaskIdentifier.invalid
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
@@ -34,8 +35,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationWillResignActive(_ application: UIApplication) {
-        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+        self.backgroundTaskID = application.beginBackgroundTask() { [weak self] in
+            // Terminate task before expiration
+            application.endBackgroundTask((self?.backgroundTaskID)!)
+            self?.backgroundTaskID = UIBackgroundTaskIdentifier.invalid
+        }
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {


### PR DESCRIPTION
## Changes
- Keep app running after going background
  - The app will be killed by OS after a while. The timing is determined automatically by the OS
- Commands available in background are follows:
  - .acceleration
  - .gravity
  - .gyro
  - .rotation
  - .compass
  - .battery

## Screenshot
![background](https://user-images.githubusercontent.com/1403842/59746677-5c301600-92b2-11e9-8a77-1c075feb1a7e.gif)

