### PR TITLE
オーバーレイの上からヘルプボタンを押せるように修正

### DIFF
--- a/ZIGSIMPlus.xcodeproj/project.pbxproj
+++ b/ZIGSIMPlus.xcodeproj/project.pbxproj
@@ -72,7 +72,7 @@
 		B30188E622B390E600CB549F /* CommandSetting.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B30188E522B390E600CB549F /* CommandSetting.storyboard */; };
 		B315239722C47E5300654A63 /* TermsOfUseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B315239622C47E5300654A63 /* TermsOfUseViewController.swift */; };
 		B315239922C4A09300654A63 /* TermsOfUse.plist in Resources */ = {isa = PBXBuildFile; fileRef = B315239822C4A09200654A63 /* TermsOfUse.plist */; };
-		B37502F122CB38820050735C /* PremiumText.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37502F022CB38820050735C /* PremiumText.swift */; };
+		B37502F322CB44C80050735C /* PremiumText.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37502F222CB44C10050735C /* PremiumText.swift */; };
 		B39DCDA222B7728C00D4E722 /* UITabBarExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39DCDA122B7728C00D4E722 /* UITabBarExtension.swift */; };
 		B39DECA922C9DE850088DD88 /* CheckMark.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39DECA822C9DE850088DD88 /* CheckMark.swift */; };
 		B3C6588722A9022600B4358B /* StandardCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B3C6588622A9022600B4358B /* StandardCell.xib */; };
@@ -192,7 +192,7 @@
 		B30188E522B390E600CB549F /* CommandSetting.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CommandSetting.storyboard; sourceTree = "<group>"; };
 		B315239622C47E5300654A63 /* TermsOfUseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfUseViewController.swift; sourceTree = "<group>"; };
 		B315239822C4A09200654A63 /* TermsOfUse.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = TermsOfUse.plist; sourceTree = "<group>"; };
-		B37502F022CB38820050735C /* PremiumText.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PremiumText.swift; sourceTree = "<group>"; };
+		B37502F222CB44C10050735C /* PremiumText.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PremiumText.swift; sourceTree = "<group>"; };
 		B39DCDA122B7728C00D4E722 /* UITabBarExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITabBarExtension.swift; sourceTree = "<group>"; };
 		B39DECA822C9DE850088DD88 /* CheckMark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckMark.swift; sourceTree = "<group>"; };
 		B3C6588622A9022600B4358B /* StandardCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = StandardCell.xib; sourceTree = "<group>"; };
@@ -488,7 +488,7 @@
 		902EB9FB227BF0DB008F1650 /* Entities */ = {
 			isa = PBXGroup;
 			children = (
-				B37502F022CB38820050735C /* PremiumText.swift */,
+				B37502F222CB44C10050735C /* PremiumText.swift */,
 				9092E4CB227EBF4D0019F1C1 /* Command.swift */,
 				B3CFE5B722ADF436009664C0 /* ModalTexts.swift */,
 				02DF072C22BB36D300F3ABE2 /* Theme.swift */,
@@ -791,7 +791,7 @@
 				02A03597229CD56E00E7399E /* AltimeterService.swift in Sources */,
 				0236461D2298253900171F73 /* NDI.cpp in Sources */,
 				B39DECA922C9DE850088DD88 /* CheckMark.swift in Sources */,
-				B37502F122CB38820050735C /* PremiumText.swift in Sources */,
+				B37502F322CB44C80050735C /* PremiumText.swift in Sources */,
 				02A8FA8C2296B62D001FB3DD /* ServiceManager.swift in Sources */,
 				63A6192B22A77DDA00B015DE /* NFCTypeNameFormatExtension.swift in Sources */,
 				02A8FA8B2296B62D001FB3DD /* BatteryService.swift in Sources */,

--- a/ZIGSIMPlus/Models/CommandAndServiceMediator.swift
+++ b/ZIGSIMPlus/Models/CommandAndServiceMediator.swift
@@ -81,6 +81,17 @@ public class CommandAndServiceMediator {
             }
         }
     }
+    
+    public func isPremiumCommand(_ command: Command) -> Bool {
+        if command == Command.ndi ||
+            command == Command.arkit ||
+            command == Command.imageDetection ||
+            command == Command.nfc ||
+            command == Command.applePencil{
+            return true
+        }
+        return false
+    }
 
     // MARK: - Private methods
 

--- a/ZIGSIMPlus/Views/CommandSelection.storyboard
+++ b/ZIGSIMPlus/Views/CommandSelection.storyboard
@@ -37,7 +37,7 @@
                                     <outlet property="delegate" destination="mba-MW-Syn" id="10U-4U-Fhl"/>
                                 </connections>
                             </tableView>
-                            <label opaque="NO" alpha="0.46000000000000002" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Omw-lC-Jla">
+                            <label opaque="NO" userInteractionEnabled="NO" alpha="0.46000000000000002" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Omw-lC-Jla">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="212"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" red="0.11630727640000001" green="1" blue="0.55855442" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/ZIGSIMPlus/Views/CommandSelectionViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSelectionViewController.swift
@@ -145,7 +145,7 @@ final class CommandSelectionViewController: UIViewController {
     }
     
     private func unlockPremiumFeature() {
-        // "tableView.reloadData()" is used for updating availability of command in tabelView after coming back from another tab.
+        // "tableView.reloadData()" is used to update availability of command.
         // e.g. If user come back to this View,after pushing the Restore Purchase Button in Setting View.
         tableView.reloadData()
         setPremiumFeatureIsHidden(true)

--- a/ZIGSIMPlus/Views/CommandSelectionViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSelectionViewController.swift
@@ -261,31 +261,20 @@ extension CommandSelectionViewController: UITableViewDataSource {
             setAvailable(true, forCell:cell)
         } else {
             setAvailable(false, forCell:cell)
-            if isPremiumCommand(Command.allCases[indexPath.row]) && !presenter.isPremiumFeaturePurchased{
+            if mediator.isPremiumCommand(Command.allCases[indexPath.row]) && !presenter.isPremiumFeaturePurchased{
                 unAvailablePremiumCommands.append(Command.allCases[indexPath.row])
                 let orderedSet: NSOrderedSet = NSOrderedSet(array: unAvailablePremiumCommands)
                 unAvailablePremiumCommands = orderedSet.array as! [Command]
             }
         }
         
-        if !presenter.isPremiumFeaturePurchased && isPremiumCommand(Command.allCases[indexPath.row]){
+        if !presenter.isPremiumFeaturePurchased && mediator.isPremiumCommand(Command.allCases[indexPath.row]){
             setAvailable(false,forCell: cell)
         }
 
         cell.initCell()
         
         return cell
-    }
-    
-    func isPremiumCommand(_ command:Command) -> Bool {
-        if command == Command.ndi ||
-            command == Command.arkit ||
-            command == Command.imageDetection ||
-            command == Command.nfc ||
-            command == Command.applePencil{
-            return true
-        }
-        return false
     }
     
     func setAvailable(_ isAvailable: Bool, forCell cell: StandardCell?) {

--- a/ZIGSIMPlus/Views/CommandSelectionViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSelectionViewController.swift
@@ -36,7 +36,9 @@ final class CommandSelectionViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
+        // "tableView.reloadData()" is used for updating availability of command in tabelView after comming back from another tab.
+        // e.g. If user come back to this View,after pushing the Restore Purchase Button in Setting View.
+        tableView.reloadData()
         // Check here to switch lock/unlock after restore
         if presenter.isPremiumFeaturePurchased {
             unlockPremiumFeature()
@@ -265,6 +267,10 @@ extension CommandSelectionViewController: UITableViewDataSource {
                 unAvailablePremiumCommands = orderedSet.array as! [Command]
             }
         }
+        
+        if !InAppPurchaseFacade.shared.isPurchased() && isPremiumCommand(Command.allCases[indexPath.row]){
+            setAvailable(false,forCell: cell)
+        }
 
         cell.initCell()
         
@@ -327,7 +333,7 @@ extension CommandSelectionViewController: UITableViewDataSource {
 extension CommandSelectionViewController: CommandSelectionPresenterDelegate {
     func showPurchaseResult(isSuccessful: Bool, title: String?, message: String?) {
         SVProgressHUD.dismiss()
-        
+        tableView.reloadData()
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         let action = UIAlertAction(title: "Close", style: .default) { _ in
             if isSuccessful {

--- a/ZIGSIMPlus/Views/CommandSelectionViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSelectionViewController.swift
@@ -261,14 +261,14 @@ extension CommandSelectionViewController: UITableViewDataSource {
             setAvailable(true, forCell:cell)
         } else {
             setAvailable(false, forCell:cell)
-            if isPremiumCommand(Command.allCases[indexPath.row]) && !InAppPurchaseFacade.shared.isPurchased(){
+            if isPremiumCommand(Command.allCases[indexPath.row]) && !presenter.isPremiumFeaturePurchased{
                 unAvailablePremiumCommands.append(Command.allCases[indexPath.row])
                 let orderedSet: NSOrderedSet = NSOrderedSet(array: unAvailablePremiumCommands)
                 unAvailablePremiumCommands = orderedSet.array as! [Command]
             }
         }
         
-        if !InAppPurchaseFacade.shared.isPurchased() && isPremiumCommand(Command.allCases[indexPath.row]){
+        if !presenter.isPremiumFeaturePurchased && isPremiumCommand(Command.allCases[indexPath.row]){
             setAvailable(false,forCell: cell)
         }
 

--- a/ZIGSIMPlus/Views/CommandSelectionViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSelectionViewController.swift
@@ -36,11 +36,11 @@ final class CommandSelectionViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        // "tableView.reloadData()" is used for updating availability of command in tabelView after comming back from another tab.
-        // e.g. If user come back to this View,after pushing the Restore Purchase Button in Setting View.
-        tableView.reloadData()
         // Check here to switch lock/unlock after restore
         if presenter.isPremiumFeaturePurchased {
+            // "tableView.reloadData()" is used for updating availability of command in tabelView after coming back from another tab.
+            // e.g. If user come back to this View,after pushing the Restore Purchase Button in Setting View.
+            tableView.reloadData()
             unlockPremiumFeature()
         } else {
             lockPremiumFeature()
@@ -333,10 +333,10 @@ extension CommandSelectionViewController: UITableViewDataSource {
 extension CommandSelectionViewController: CommandSelectionPresenterDelegate {
     func showPurchaseResult(isSuccessful: Bool, title: String?, message: String?) {
         SVProgressHUD.dismiss()
-        tableView.reloadData()
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         let action = UIAlertAction(title: "Close", style: .default) { _ in
             if isSuccessful {
+                self.tableView.reloadData()
                 self.unlockPremiumFeature()
             }
             self.tableView.isUserInteractionEnabled = true

--- a/ZIGSIMPlus/Views/CommandSelectionViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSelectionViewController.swift
@@ -38,9 +38,6 @@ final class CommandSelectionViewController: UIViewController {
         super.viewWillAppear(animated)
         // Check here to switch lock/unlock after restore
         if presenter.isPremiumFeaturePurchased {
-            // "tableView.reloadData()" is used for updating availability of command in tabelView after coming back from another tab.
-            // e.g. If user come back to this View,after pushing the Restore Purchase Button in Setting View.
-            tableView.reloadData()
             unlockPremiumFeature()
         } else {
             lockPremiumFeature()
@@ -148,6 +145,9 @@ final class CommandSelectionViewController: UIViewController {
     }
     
     private func unlockPremiumFeature() {
+        // "tableView.reloadData()" is used for updating availability of command in tabelView after coming back from another tab.
+        // e.g. If user come back to this View,after pushing the Restore Purchase Button in Setting View.
+        tableView.reloadData()
         setPremiumFeatureIsHidden(true)
     }
     
@@ -336,7 +336,6 @@ extension CommandSelectionViewController: CommandSelectionPresenterDelegate {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         let action = UIAlertAction(title: "Close", style: .default) { _ in
             if isSuccessful {
-                self.tableView.reloadData()
                 self.unlockPremiumFeature()
             }
             self.tableView.isUserInteractionEnabled = true


### PR DESCRIPTION
# 変更点
- オーバーレイ用のUILabelの`User Interaction Enabled`のチェックを外して、テーブルを選択できるように修正した。
- 上記変更に伴い、課金/RestorePurchas前の有料コマンドを選択できないように修正した。
- 課金/RestorePurchase直後に有料コマンドを選択できるようにテーブルの更新処理を追加

# 画面イメージ
![fixoverlay](https://user-images.githubusercontent.com/44634617/60504731-200ea380-9cfd-11e9-99bd-9d42e0d79c29.gif)
