### PR TITLE
Update text for purchase modal

### DIFF
--- a/ZIGSIMPlus/Entities/PremiumText.swift
+++ b/ZIGSIMPlus/Entities/PremiumText.swift
@@ -8,7 +8,9 @@
 
 import Foundation
 
-let premiumTextTitle: String = "These functions are charged"
+let premiumTextTitle: String = "Explore more with premium features"
 let premiumTextBody: String = """
-You must charge to use these functions.
+You have to purchase to unlock these functions.
+
+Note that Apple Pencil function only works on Apple Pencil compatible devices, that are some of iPad models.
 """

--- a/ZIGSIMPlus/Views/CommandSelectionViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSelectionViewController.swift
@@ -173,8 +173,11 @@ final class CommandSelectionViewController: UIViewController {
     
     private func setAlertMessage(_ message: String, _ alertType: alertModalType) {
         var msg = message
-        if  alertType == alertModalType.premium && !isAvailablePremiumCommands() {
-            msg = premiumTextBody + "\n\nBut the following function cannot be used on your device:"
+        if  alertType == alertModalType.premium && unavailableFunctionCount > 0 {
+            msg += (unavailableFunctionCount >= 2
+                ? "\n\nThe following functions don't work on this device:"
+                : "\n\nThe following function doesn't work on this device:")
+            
             for unAvailablePremiumCommand in unAvailablePremiumCommands {
                 msg = msg + "\n- " + unAvailablePremiumCommand.rawValue
             }
@@ -189,7 +192,6 @@ final class CommandSelectionViewController: UIViewController {
         }
         
         convertMeaageFromStringToAttributedText(msg)
-        
     }
     
     private func convertMeaageFromStringToAttributedText(_ msg:String) {
@@ -198,13 +200,17 @@ final class CommandSelectionViewController: UIViewController {
         alert.setValue(aText, forKey: "attributedMessage")
     }
     
-    private func isAvailablePremiumCommands() -> Bool {
-        if unAvailablePremiumCommands.count != 0 ||
-            !VideoCaptureService.shared.isDepthRearCameraAvailable() ||
-            !VideoCaptureService.shared.isDepthFrontCameraAvailable() {
-            return false
+    private var unavailableFunctionCount: Int {
+        var count = unAvailablePremiumCommands.count
+        if !VideoCaptureService.shared.isDepthRearCameraAvailable() {
+            count += 1
+        } else {
+            if !VideoCaptureService.shared.isDepthFrontCameraAvailable() {
+                count += 1
+            }
         }
-        return true
+        
+        return count
     }
 }
 

--- a/ZIGSIMPlus/Views/CommandSelectionViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSelectionViewController.swift
@@ -68,7 +68,8 @@ final class CommandSelectionViewController: UIViewController {
     }
     
     @IBAction func actionButton(_ sender: UIButton) {
-        showAlertModal(alertType: .premium)
+        let message = getAlertMessageForPurchase()
+        showAlertWithMarkdownMessage(title: premiumTextTitle, message: message, alertType: .premium)
     }
     
     public func showDetail(commandNo: Int) {
@@ -98,17 +99,16 @@ final class CommandSelectionViewController: UIViewController {
             fatalError("Invalid command: \(command)")
         }
 
-        showAlertModal(title:title, message: msg, alertType: .detailSetting)
+        showAlertWithMarkdownMessage(title:title, message: msg, alertType: .detailSetting)
     }
     
-    func showAlertModal(title: String? = nil, message: String? = nil, alertType: alertModalType) {
+    func showAlertWithMarkdownMessage(title: String, message: String, alertType: alertModalType) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let attributedText = convertMessageFromStringToAttributedText(message)
+        alert.setValue(attributedText, forKey: "attributedMessage")
+        
         switch alertType {
         case .premium:
-            let text = getAlertMessageForPurchase()
-            alert.setValue(text, forKey: "attributedMessage")
-            alert.title = premiumTextTitle
-            
             alert.addAction(UIAlertAction(title: "Back", style: .default))
             alert.addAction(UIAlertAction(title: "Purchase", style: .default, handler: { action in
                 self.tableView.isUserInteractionEnabled = false
@@ -116,10 +116,6 @@ final class CommandSelectionViewController: UIViewController {
                 self.presenter.purchase()
             }))
         case .detailSetting:
-            guard let msg = message else { fatalError("Message nil") }
-            let text = convertMessageFromStringToAttributedText(msg)
-            alert.setValue(text, forKey: "attributedMessage")
-            
             alert.addAction(UIAlertAction(title: "See Docs", style: .default, handler: { action in
                 UIApplication.shared.open(URL(string: "https://zig-project.com/")!, options: [:])
             }))
@@ -170,7 +166,7 @@ final class CommandSelectionViewController: UIViewController {
                                         height: unlockPremiumFeatureButton.frame.size.height)
     }
     
-    private func getAlertMessageForPurchase() -> NSMutableAttributedString {
+    private func getAlertMessageForPurchase() -> String {
         var message = premiumTextBody
         if  unavailableFunctionCount > 0 {
             message += (unavailableFunctionCount >= 2
@@ -189,14 +185,13 @@ final class CommandSelectionViewController: UIViewController {
                 }
             }
         }
-
-        return convertMessageFromStringToAttributedText(message)
+        
+        return message
     }
     
     private func convertMessageFromStringToAttributedText(_ msg: String) -> NSMutableAttributedString {
         let markdownParser = MarkdownParser()
         return NSMutableAttributedString(attributedString: markdownParser.parse(msg))
-//        alert.setValue(aText, forKey: "attributedMessage")
     }
     
     private var unavailableFunctionCount: Int {

--- a/ZIGSIMPlus/Views/CommandSelectionViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSelectionViewController.swift
@@ -168,8 +168,8 @@ final class CommandSelectionViewController: UIViewController {
     
     private func getAlertMessageForPurchase() -> String {
         var message = premiumTextBody
-        if  unavailableFunctionCount > 0 {
-            message += (unavailableFunctionCount >= 2
+        if  unavailablePremiumFunctionCount > 0 {
+            message += (unavailablePremiumFunctionCount >= 2
                 ? "\n\nThe following functions don't work on this device:"
                 : "\n\nThe following function doesn't work on this device:")
 
@@ -194,7 +194,7 @@ final class CommandSelectionViewController: UIViewController {
         return NSMutableAttributedString(attributedString: markdownParser.parse(msg))
     }
     
-    private var unavailableFunctionCount: Int {
+    private var unavailablePremiumFunctionCount: Int {
         var count = unAvailablePremiumCommands.count
         if !VideoCaptureService.shared.isDepthRearCameraAvailable() {
             count += 1

--- a/ZIGSIMPlus/Views/CommandSelectionViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSelectionViewController.swift
@@ -174,16 +174,16 @@ final class CommandSelectionViewController: UIViewController {
     private func setAlertMessage(_ message: String, _ alertType: alertModalType) {
         var msg = message
         if  alertType == alertModalType.premium && !isAvailablePremiumCommands() {
-            msg = premiumTextBody + "\n\nBut the following function can not be used on your device."
+            msg = premiumTextBody + "\n\nBut the following function cannot be used on your device:"
             for unAvailablePremiumCommand in unAvailablePremiumCommands {
-                msg = msg + "\n・" + unAvailablePremiumCommand.rawValue
+                msg = msg + "\n- " + unAvailablePremiumCommand.rawValue
             }
             if !unAvailablePremiumCommands.contains(Command.ndi) {
                 if !VideoCaptureService.shared.isDepthRearCameraAvailable() {
-                    msg = msg + "\n・NDI Depth function."
+                    msg = msg + "\n- NDI Depth function"
                 }
                 if VideoCaptureService.shared.isDepthRearCameraAvailable() && !VideoCaptureService.shared.isDepthFrontCameraAvailable(){
-                    msg = msg + "\n・NDI Depth function on front camera."
+                    msg = msg + "\n- NDI Depth function on front camera"
                 }
             }
         }


### PR DESCRIPTION
# Changes
- Update English text for the modal before purchase
- Refactor displaying alert

# TODO (maybe after the first release)
Lock & unlock related process should be segregated into View and Presenter properly. 

![purchase_modal](https://user-images.githubusercontent.com/19822628/60698465-6dbc2380-9f2a-11e9-8a09-3dc23fdd06ca.png)
