### PR TITLE
Fix app crash on sleep / Refactor scheduler

### DIFF
--- a/ZIGSIMPlus.xcodeproj/project.pbxproj
+++ b/ZIGSIMPlus.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0212CDAF22A6219E00A83C16 /* MotionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0212CDAE22A6219E00A83C16 /* MotionService.swift */; };
 		0212CDB322A6356500A83C16 /* VideoCaptureViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0212CDB222A6356500A83C16 /* VideoCaptureViewController.swift */; };
 		021EEA0D22C46814007174E3 /* InAppPurchaseFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021EEA0C22C46813007174E3 /* InAppPurchaseFacade.swift */; };
+		021F240E22D39A580065D641 /* CommandPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021F240D22D39A580065D641 /* CommandPlayer.swift */; };
 		0236461B2298253900171F73 /* VideoCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023644AE2298253800171F73 /* VideoCaptureService.swift */; };
 		0236461C2298253900171F73 /* libndi_ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 023644BF2298253800171F73 /* libndi_ios.a */; };
 		0236461D2298253900171F73 /* NDI.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 023644C32298253800171F73 /* NDI.cpp */; };
@@ -106,6 +107,7 @@
 		0212CDAE22A6219E00A83C16 /* MotionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MotionService.swift; sourceTree = "<group>"; };
 		0212CDB222A6356500A83C16 /* VideoCaptureViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCaptureViewController.swift; sourceTree = "<group>"; };
 		021EEA0C22C46813007174E3 /* InAppPurchaseFacade.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InAppPurchaseFacade.swift; sourceTree = "<group>"; };
+		021F240D22D39A580065D641 /* CommandPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPlayer.swift; sourceTree = "<group>"; };
 		023644AE2298253800171F73 /* VideoCaptureService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoCaptureService.swift; sourceTree = "<group>"; };
 		023644B12298253800171F73 /* Processing.NDI.compat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Processing.NDI.compat.h; sourceTree = "<group>"; };
 		023644B22298253800171F73 /* Processing.NDI.utilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Processing.NDI.utilities.h; sourceTree = "<group>"; };
@@ -525,6 +527,7 @@
 				903BA770227D6C2100A2C378 /* AppSettingModel.swift */,
 				02A8FA8D2296B6DA001FB3DD /* NetworkAdapter.swift */,
 				021EEA0C22C46813007174E3 /* InAppPurchaseFacade.swift */,
+				021F240D22D39A580065D641 /* CommandPlayer.swift */,
 				63C02A2B2293D97700551E2F /* CommandAndServiceMediator.swift */,
 				02A8FA822296B62D001FB3DD /* Services */,
 			);
@@ -877,6 +880,7 @@
 				B3CFE5BA22AE67AC009664C0 /* CommandOutputViewSettingsTableCell.swift in Sources */,
 				02381A6F22CF5496007D4863 /* AppSettingModelAutoSave.generated.swift in Sources */,
 				02621F5622A4F9140071E9D2 /* StringExtension.swift in Sources */,
+				021F240E22D39A580065D641 /* CommandPlayer.swift in Sources */,
 				B3C6588922A9028500B4358B /* StandardCell.swift in Sources */,
 				021EEA0D22C46814007174E3 /* InAppPurchaseFacade.swift in Sources */,
 				0236461E2298253900171F73 /* NDIAdapter.mm in Sources */,

--- a/ZIGSIMPlus/AppDelegate.swift
+++ b/ZIGSIMPlus/AppDelegate.swift
@@ -13,7 +13,6 @@ import StoreKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
-    let mediator = CommandAndServiceMediator()
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // It's recommended to add a transaction queue observer at application launch
@@ -22,6 +21,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Inject dependency here
         let tabBarController = window?.rootViewController as! UITabBarController
+        let mediator = CommandAndServiceMediator()
+
         for viewController in tabBarController.viewControllers! {
             if type(of: viewController) == CommandSelectionTabNavigationController.self {
                 let vc = viewController as! CommandSelectionTabNavigationController
@@ -42,7 +43,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationWillResignActive(_ application: UIApplication) {
-        mediator.pause()
+        CommandPlayer.shared.pause()
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {}
@@ -50,7 +51,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationWillEnterForeground(_ application: UIApplication) {}
 
     func applicationDidBecomeActive(_ application: UIApplication) {
-        mediator.resume()
+        CommandPlayer.shared.resume()
     }
 
     func applicationWillTerminate(_ application: UIApplication) {

--- a/ZIGSIMPlus/AppDelegate.swift
+++ b/ZIGSIMPlus/AppDelegate.swift
@@ -19,22 +19,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // See https://developer.apple.com/library/archive/technotes/tn2387/_index.html
         SKPaymentQueue.default().add(InAppPurchaseFacade.shared)
 
-        // Inject dependency here
-        let tabBarController = window?.rootViewController as! UITabBarController
-        let mediator = CommandAndServiceMediator()
-
-        for viewController in tabBarController.viewControllers! {
-            if type(of: viewController) == CommandSelectionTabNavigationController.self {
-                let vc = viewController as! CommandSelectionTabNavigationController
-                vc.setMediator(mediator)
-            } else if type(of: viewController) == CommandOutputTabNavigationController.self {
-                let vc = viewController as! CommandOutputTabNavigationController
-                vc.setMediator(mediator)
-            } else {
-                print("else")
-            }
-        }
-
         // Setup tab bar styles
         UITabBar.appearance().barTintColor = Theme.dark
         UITabBar.appearance().tintColor = Theme.main

--- a/ZIGSIMPlus/AppDelegate.swift
+++ b/ZIGSIMPlus/AppDelegate.swift
@@ -13,6 +13,7 @@ import StoreKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
+    let mediator = CommandAndServiceMediator()
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // It's recommended to add a transaction queue observer at application launch
@@ -21,7 +22,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Inject dependency here
         let tabBarController = window?.rootViewController as! UITabBarController
-        let mediator = CommandAndServiceMediator()
         for viewController in tabBarController.viewControllers! {
             if type(of: viewController) == CommandSelectionTabNavigationController.self {
                 let vc = viewController as! CommandSelectionTabNavigationController
@@ -42,21 +42,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationWillResignActive(_ application: UIApplication) {
-        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+        mediator.pause()
     }
 
-    func applicationDidEnterBackground(_ application: UIApplication) {
-        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-    }
+    func applicationDidEnterBackground(_ application: UIApplication) {}
 
-    func applicationWillEnterForeground(_ application: UIApplication) {
-        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
-    }
+    func applicationWillEnterForeground(_ application: UIApplication) {}
 
     func applicationDidBecomeActive(_ application: UIApplication) {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+        mediator.resume()
     }
 
     func applicationWillTerminate(_ application: UIApplication) {

--- a/ZIGSIMPlus/Entities/Command.swift
+++ b/ZIGSIMPlus/Entities/Command.swift
@@ -53,4 +53,13 @@ public enum Command: String, CaseIterable {
         case .battery: return DefaultsKeys.isBatteryCommandActive
         }
     }
+
+    var isPremium: Bool {
+        switch self {
+        case .ndi, .arkit, .imageDetection, .nfc, .applePencil:
+            return true
+        default:
+            return false
+        }
+    }
 }

--- a/ZIGSIMPlus/Models/CommandAndServiceMediator.swift
+++ b/ZIGSIMPlus/Models/CommandAndServiceMediator.swift
@@ -15,7 +15,7 @@ public class CommandAndServiceMediator {
     /// Returns if the service for given command is available.
     ///
     /// Simultaneous use of multiple commands accessing camera is not allowed.
-    public func isAvailable(_ command: Command) -> Bool {
+    public static func isAvailable(_ command: Command) -> Bool {
         switch command {
         case .acceleration, .gravity, .gyro, .quaternion:
             return MotionService.shared.isAvailable()
@@ -56,7 +56,7 @@ public class CommandAndServiceMediator {
         }
     }
 
-    public func isPremiumCommand(_ command: Command) -> Bool {
+    public static func isPremiumCommand(_ command: Command) -> Bool {
         if command == Command.ndi ||
             command == Command.arkit ||
             command == Command.imageDetection ||
@@ -69,7 +69,7 @@ public class CommandAndServiceMediator {
 
     // MARK: - Private methods
 
-    private func isCameraAvailable(for command: Command) -> Bool {
+    private static func isCameraAvailable(for command: Command) -> Bool {
         // When camera is set to on by other command,
         // user cannot use camera
         return !AppSettingModel.shared.isCameraUsed(exceptBy: command)

--- a/ZIGSIMPlus/Models/CommandAndServiceMediator.swift
+++ b/ZIGSIMPlus/Models/CommandAndServiceMediator.swift
@@ -56,17 +56,6 @@ public class CommandAndServiceMediator {
         }
     }
 
-    public static func isPremiumCommand(_ command: Command) -> Bool {
-        if command == Command.ndi ||
-            command == Command.arkit ||
-            command == Command.imageDetection ||
-            command == Command.nfc ||
-            command == Command.applePencil{
-            return true
-        }
-        return false
-    }
-
     public static func startCommand(_ command: Command) {
         switch command {
         case .acceleration, .gravity, .gyro, .quaternion:

--- a/ZIGSIMPlus/Models/CommandAndServiceMediator.swift
+++ b/ZIGSIMPlus/Models/CommandAndServiceMediator.swift
@@ -67,6 +67,68 @@ public class CommandAndServiceMediator {
         return false
     }
 
+    public static func startCommand(_ command: Command) {
+        switch command {
+        case .acceleration, .gravity, .gyro, .quaternion:
+            MotionService.shared.start()
+        case .touch, .applePencil:
+            TouchService.shared.enable()
+        case .battery:
+            BatteryService.shared.startBattery()
+        case .compass:
+            LocationService.shared.startCompass()
+        case .gps:
+            LocationService.shared.startGps()
+        case .beacon:
+            LocationService.shared.startBeacons()
+        case .pressure:
+            AltimeterService.shared.startAltimeter()
+        case .proximity:
+            ProximityService.shared.start()
+        case .micLevel:
+            AudioLevelService.shared.start()
+        case .arkit:
+            ArkitService.shared.start()
+        case .remoteControl:
+            RemoteControlService.shared.start()
+        case .ndi, .imageDetection:
+            VideoCaptureService.shared.start()
+        case .nfc:
+            NFCService.shared.start()
+        }
+    }
+
+    public static func stopCommand(_ command: Command) {
+        switch command {
+        case .acceleration, .gravity, .gyro, .quaternion:
+            MotionService.shared.stop()
+        case .touch, .applePencil:
+            TouchService.shared.disable()
+        case .battery:
+            BatteryService.shared.stopBattery()
+        case .compass:
+            LocationService.shared.stopCompass()
+        case .gps:
+            LocationService.shared.stopGps()
+        case .beacon:
+            LocationService.shared.stopBeacons()
+        case .pressure:
+            AltimeterService.shared.stopAltimeter()
+        case .proximity:
+            ProximityService.shared.stop()
+        case .micLevel:
+            AudioLevelService.shared.stop()
+        case .arkit:
+            ArkitService.shared.stop()
+        case .remoteControl:
+            RemoteControlService.shared.stop()
+        case .ndi, .imageDetection:
+            VideoCaptureService.shared.stop()
+        case .nfc:
+            NFCService.shared.stop()
+        }
+    }
+
     // MARK: - Private methods
 
     private static func isCameraAvailable(for command: Command) -> Bool {

--- a/ZIGSIMPlus/Models/CommandAndServiceMediator.swift
+++ b/ZIGSIMPlus/Models/CommandAndServiceMediator.swift
@@ -8,17 +8,7 @@
 
 import Foundation
 
-enum CommandState {
-    case playing
-    case paused
-    case stopped
-}
-
 public class CommandAndServiceMediator {
-
-    private var updatingTimer: Timer?
-    public var onUpdate: (() -> Void)?
-    private var state: CommandState = .stopped
 
     // MARK: - Public methods
 
@@ -66,34 +56,6 @@ public class CommandAndServiceMediator {
         }
     }
 
-    public func play() {
-        if state == .stopped {
-            startCommands()
-            state = .playing
-        }
-    }
-
-    public func pause() {
-        if state == .playing {
-            stopCommands()
-            state = .paused
-        }
-    }
-
-    public func resume() {
-        if state == .paused {
-            startCommands()
-            state = .playing
-        }
-    }
-
-    public func stop() {
-        if state == .playing {
-            stopCommands()
-            state = .stopped
-        }
-    }
-
     public func isPremiumCommand(_ command: Command) -> Bool {
         if command == Command.ndi ||
             command == Command.arkit ||
@@ -106,120 +68,6 @@ public class CommandAndServiceMediator {
     }
 
     // MARK: - Private methods
-
-    private func startCommands() {
-        updatingTimer = Timer.scheduledTimer(
-            timeInterval: Utils.getMessageInterval(),
-            target: self,
-            selector: #selector(self.monitorCommands),
-            userInfo: nil,
-            repeats: true)
-
-        for command in Command.allCases {
-            if isActive(command) {
-                startCommand(command)
-            }
-        }
-
-        ServiceManager.shared.send()
-        onUpdate?()
-    }
-
-    @objc private func monitorCommands() {
-        if isActive(.battery) {
-            BatteryService.shared.updateBattery()
-        }
-        if isActive(.remoteControl) {
-            RemoteControlService.shared.update()
-        }
-
-        ServiceManager.shared.send()
-        onUpdate?()
-    }
-
-    private func stopCommands() {
-        guard let t = updatingTimer else { return }
-        if t.isValid {
-            t.invalidate()
-        }
-
-        for command in Command.allCases {
-            if isActive(command) {
-                stopCommand(command)
-            }
-        }
-
-        NetworkAdapter.shared.close()
-    }
-
-    private func startCommand(_ command: Command) {
-        switch command {
-        case .acceleration, .gravity, .gyro, .quaternion:
-            MotionService.shared.start()
-        case .touch, .applePencil:
-            TouchService.shared.enable()
-        case .battery:
-            BatteryService.shared.startBattery()
-        case .compass:
-            LocationService.shared.startCompass()
-        case .gps:
-            LocationService.shared.startGps()
-        case .beacon:
-            LocationService.shared.startBeacons()
-        case .pressure:
-            AltimeterService.shared.startAltimeter()
-        case .proximity:
-            ProximityService.shared.start()
-        case .micLevel:
-            AudioLevelService.shared.start()
-        case .arkit:
-            ArkitService.shared.start()
-        case .remoteControl:
-            RemoteControlService.shared.start()
-        case .ndi, .imageDetection:
-            VideoCaptureService.shared.start()
-        case .nfc:
-            NFCService.shared.start()
-        }
-    }
-
-    private func stopCommand(_ command: Command) {
-        switch command {
-        case .acceleration, .gravity, .gyro, .quaternion:
-            MotionService.shared.stop()
-        case .touch, .applePencil:
-            TouchService.shared.disable()
-        case .battery:
-            BatteryService.shared.stopBattery()
-        case .compass:
-            LocationService.shared.stopCompass()
-        case .gps:
-            LocationService.shared.stopGps()
-        case .beacon:
-            LocationService.shared.stopBeacons()
-        case .pressure:
-            AltimeterService.shared.stopAltimeter()
-        case .proximity:
-            ProximityService.shared.stop()
-        case .micLevel:
-            AudioLevelService.shared.stop()
-        case .arkit:
-            ArkitService.shared.stop()
-        case .remoteControl:
-            RemoteControlService.shared.stop()
-        case .ndi, .imageDetection:
-            VideoCaptureService.shared.stop()
-        case .nfc:
-            NFCService.shared.stop()
-        }
-    }
-
-    private func isActive(_ command: Command) -> Bool {
-        guard let b = AppSettingModel.shared.isActiveByCommand[command] else {
-            fatalError("AppSetting for Command \"\(command)\" is nil")
-        }
-        return b
-    }
 
     private func isCameraAvailable(for command: Command) -> Bool {
         // When camera is set to on by other command,

--- a/ZIGSIMPlus/Models/CommandPlayer.swift
+++ b/ZIGSIMPlus/Models/CommandPlayer.swift
@@ -64,7 +64,7 @@ public class CommandPlayer {
 
         for command in Command.allCases {
             if isActive(command) {
-                startCommand(command)
+                CommandAndServiceMediator.startCommand(command)
             }
         }
 
@@ -96,73 +96,11 @@ public class CommandPlayer {
 
         for command in Command.allCases {
             if isActive(command) {
-                stopCommand(command)
+                CommandAndServiceMediator.stopCommand(command)
             }
         }
 
         NetworkAdapter.shared.close()
-    }
-
-    private func startCommand(_ command: Command) {
-        switch command {
-        case .acceleration, .gravity, .gyro, .quaternion:
-            MotionService.shared.start()
-        case .touch, .applePencil:
-            TouchService.shared.enable()
-        case .battery:
-            BatteryService.shared.startBattery()
-        case .compass:
-            LocationService.shared.startCompass()
-        case .gps:
-            LocationService.shared.startGps()
-        case .beacon:
-            LocationService.shared.startBeacons()
-        case .pressure:
-            AltimeterService.shared.startAltimeter()
-        case .proximity:
-            ProximityService.shared.start()
-        case .micLevel:
-            AudioLevelService.shared.start()
-        case .arkit:
-            ArkitService.shared.start()
-        case .remoteControl:
-            RemoteControlService.shared.start()
-        case .ndi, .imageDetection:
-            VideoCaptureService.shared.start()
-        case .nfc:
-            NFCService.shared.start()
-        }
-    }
-
-    private func stopCommand(_ command: Command) {
-        switch command {
-        case .acceleration, .gravity, .gyro, .quaternion:
-            MotionService.shared.stop()
-        case .touch, .applePencil:
-            TouchService.shared.disable()
-        case .battery:
-            BatteryService.shared.stopBattery()
-        case .compass:
-            LocationService.shared.stopCompass()
-        case .gps:
-            LocationService.shared.stopGps()
-        case .beacon:
-            LocationService.shared.stopBeacons()
-        case .pressure:
-            AltimeterService.shared.stopAltimeter()
-        case .proximity:
-            ProximityService.shared.stop()
-        case .micLevel:
-            AudioLevelService.shared.stop()
-        case .arkit:
-            ArkitService.shared.stop()
-        case .remoteControl:
-            RemoteControlService.shared.stop()
-        case .ndi, .imageDetection:
-            VideoCaptureService.shared.stop()
-        case .nfc:
-            NFCService.shared.stop()
-        }
     }
 
     private func isActive(_ command: Command) -> Bool {

--- a/ZIGSIMPlus/Models/CommandPlayer.swift
+++ b/ZIGSIMPlus/Models/CommandPlayer.swift
@@ -1,0 +1,170 @@
+//
+//  CommandPlayer.swift
+//  ZIGSIMPlus
+//
+//  Created by Takayosi Amagi on 2019/07/09.
+//  Copyright © 2019 1→10, Inc. All rights reserved.
+//
+
+import Foundation
+
+enum CommandPlayerState {
+    case playing
+    case paused
+    case stopped
+}
+
+public class CommandPlayer {
+    static let shared = CommandPlayer()
+    private init() {}
+
+    private var updatingTimer: Timer?
+    public var onUpdate: (() -> Void)?
+    private var state: CommandPlayerState = .stopped
+
+    // MARK: - Public methods
+
+    public func play() {
+        if state == .stopped {
+            startCommands()
+            state = .playing
+        }
+    }
+
+    public func pause() {
+        if state == .playing {
+            stopCommands()
+            state = .paused
+        }
+    }
+
+    public func resume() {
+        if state == .paused {
+            startCommands()
+            state = .playing
+        }
+    }
+
+    public func stop() {
+        if state == .playing {
+            stopCommands()
+            state = .stopped
+        }
+    }
+
+    // MARK: - Private methods
+
+    private func startCommands() {
+        updatingTimer = Timer.scheduledTimer(
+            timeInterval: Utils.getMessageInterval(),
+            target: self,
+            selector: #selector(self.monitorCommands),
+            userInfo: nil,
+            repeats: true)
+
+        for command in Command.allCases {
+            if isActive(command) {
+                startCommand(command)
+            }
+        }
+
+        ServiceManager.shared.send()
+        onUpdate?()
+    }
+
+    @objc private func monitorCommands() {
+        if isActive(.battery) {
+            BatteryService.shared.updateBattery()
+        }
+        if isActive(.remoteControl) {
+            RemoteControlService.shared.update()
+        }
+
+        ServiceManager.shared.send()
+        onUpdate?()
+    }
+
+    private func stopCommands() {
+        guard let t = updatingTimer else { return }
+        if t.isValid {
+            t.invalidate()
+        }
+
+        for command in Command.allCases {
+            if isActive(command) {
+                stopCommand(command)
+            }
+        }
+
+        NetworkAdapter.shared.close()
+    }
+
+    private func startCommand(_ command: Command) {
+        switch command {
+        case .acceleration, .gravity, .gyro, .quaternion:
+            MotionService.shared.start()
+        case .touch, .applePencil:
+            TouchService.shared.enable()
+        case .battery:
+            BatteryService.shared.startBattery()
+        case .compass:
+            LocationService.shared.startCompass()
+        case .gps:
+            LocationService.shared.startGps()
+        case .beacon:
+            LocationService.shared.startBeacons()
+        case .pressure:
+            AltimeterService.shared.startAltimeter()
+        case .proximity:
+            ProximityService.shared.start()
+        case .micLevel:
+            AudioLevelService.shared.start()
+        case .arkit:
+            ArkitService.shared.start()
+        case .remoteControl:
+            RemoteControlService.shared.start()
+        case .ndi, .imageDetection:
+            VideoCaptureService.shared.start()
+        case .nfc:
+            NFCService.shared.start()
+        }
+    }
+
+    private func stopCommand(_ command: Command) {
+        switch command {
+        case .acceleration, .gravity, .gyro, .quaternion:
+            MotionService.shared.stop()
+        case .touch, .applePencil:
+            TouchService.shared.disable()
+        case .battery:
+            BatteryService.shared.stopBattery()
+        case .compass:
+            LocationService.shared.stopCompass()
+        case .gps:
+            LocationService.shared.stopGps()
+        case .beacon:
+            LocationService.shared.stopBeacons()
+        case .pressure:
+            AltimeterService.shared.stopAltimeter()
+        case .proximity:
+            ProximityService.shared.stop()
+        case .micLevel:
+            AudioLevelService.shared.stop()
+        case .arkit:
+            ArkitService.shared.stop()
+        case .remoteControl:
+            RemoteControlService.shared.stop()
+        case .ndi, .imageDetection:
+            VideoCaptureService.shared.stop()
+        case .nfc:
+            NFCService.shared.stop()
+        }
+    }
+
+    private func isActive(_ command: Command) -> Bool {
+        guard let b = AppSettingModel.shared.isActiveByCommand[command] else {
+            fatalError("AppSetting for Command \"\(command)\" is nil")
+        }
+        return b
+    }
+}

--- a/ZIGSIMPlus/Models/CommandPlayer.swift
+++ b/ZIGSIMPlus/Models/CommandPlayer.swift
@@ -68,7 +68,9 @@ public class CommandPlayer {
             }
         }
 
-        ServiceManager.shared.send()
+        let data = ServiceManager.shared.getData()
+        NetworkAdapter.shared.send(data)
+
         onUpdate?()
     }
 
@@ -80,7 +82,9 @@ public class CommandPlayer {
             RemoteControlService.shared.update()
         }
 
-        ServiceManager.shared.send()
+        let data = ServiceManager.shared.getData()
+        NetworkAdapter.shared.send(data)
+
         onUpdate?()
     }
 

--- a/ZIGSIMPlus/Models/NetworkAdapter.swift
+++ b/ZIGSIMPlus/Models/NetworkAdapter.swift
@@ -21,13 +21,19 @@ public class NetworkAdapter {
     var error: Error?
     
     /// Send data over TCP / UDP automatically
-    func send(_ data: Data){
+    func send(_ data: Data) {
         switch AppSettingModel.shared.transportProtocol {
         case .TCP:
             sendTCP(data)
         case .UDP:
             sendUDP(data)
         }
+    }
+
+    func close() {
+        udpClient.close()
+        tcpClient.close()
+        print(">>>>>>>>>>>> close")
     }
 
     /// Get error description to show in output view

--- a/ZIGSIMPlus/Models/NetworkAdapter.swift
+++ b/ZIGSIMPlus/Models/NetworkAdapter.swift
@@ -33,7 +33,6 @@ public class NetworkAdapter {
     func close() {
         udpClient.close()
         tcpClient.close()
-        print(">>>>>>>>>>>> close")
     }
 
     /// Get error description to show in output view

--- a/ZIGSIMPlus/Models/Services/ServiceManager.swift
+++ b/ZIGSIMPlus/Models/Services/ServiceManager.swift
@@ -17,20 +17,20 @@ protocol Service {
     func toJSON() throws -> JSON
 }
 
-/// ServiceManager creates OSC / JSON data and send it over TCP / UDP.
+/// ServiceManager creates OSC / JSON data.
 /// It also creates single string for output view.
 ///
 /// This class does following things:
 /// - Fetch data from services
 /// - Merge them into single OSC / JSON data
 /// - Add device data to it
-/// - Send it over network with NetworkAdapter
 class ServiceManager {
     static let shared = ServiceManager()
     private init() {}
 
-    public func send() {
+    public func getData() -> Data {
         let data: Data
+
         if AppSettingModel.shared.transportFormat == .OSC {
             let osc = getOSC()
             data = osc.data
@@ -39,7 +39,8 @@ class ServiceManager {
             let json = getJSON()
             data = try! json.rawData()
         }
-        NetworkAdapter.shared.send(data)
+
+        return data
     }
 
     public func getLog() -> String {

--- a/ZIGSIMPlus/Presenters/CommandOutputPresenter.swift
+++ b/ZIGSIMPlus/Presenters/CommandOutputPresenter.swift
@@ -30,7 +30,7 @@ final class CommandOutputPresenter: CommandOutputPresenterProtocol {
         self.view = view
         self.mediator = mediator
 
-        mediator.onUpdate = {
+        CommandPlayer.shared.onUpdate = {
             self.updateOutput()
         }
     }
@@ -43,12 +43,12 @@ final class CommandOutputPresenter: CommandOutputPresenterProtocol {
     }
 
     func startCommands() {
-        mediator.play()
+        CommandPlayer.shared.play()
         view.updateSettings(with: AppSettingModel.shared.getSettingsForOutput())
     }
 
     func stopCommands() {
-        mediator.stop()
+        CommandPlayer.shared.stop()
     }
 
     func isCameraUsed() -> Bool {

--- a/ZIGSIMPlus/Presenters/CommandOutputPresenter.swift
+++ b/ZIGSIMPlus/Presenters/CommandOutputPresenter.swift
@@ -25,11 +25,14 @@ protocol CommandOutputPresenterDelegate: AnyObject {
 final class CommandOutputPresenter: CommandOutputPresenterProtocol {
     private weak var view: CommandOutputPresenterDelegate!
     private var mediator: CommandAndServiceMediator
-    private var updatingTimer: Timer?
     
     init(view: CommandOutputPresenterDelegate, mediator: CommandAndServiceMediator) {
         self.view = view
         self.mediator = mediator
+
+        mediator.onUpdate = {
+            self.updateOutput()
+        }
     }
     
     // This cannnot be defined in AppDelegate, because subviews cannot be accessed from AppDelegate
@@ -39,42 +42,13 @@ final class CommandOutputPresenter: CommandOutputPresenterProtocol {
         factory.createVideoCapturePresenter(parentView: view as! CommandOutputViewController)
     }
 
-    // MARK: Start commands
     func startCommands() {
-        let interval = Utils.getMessageInterval()
-
-        updatingTimer = Timer.scheduledTimer(
-            timeInterval: interval,
-            target: self,
-            selector: #selector(self.monitorCommands),
-            userInfo: nil,
-            repeats: true)
-
-        mediator.startActiveCommands()
-        ServiceManager.shared.send()
-        updateOutput()
-
-        let settings = AppSettingModel.shared.getSettingsForOutput()
-        view.updateSettings(with: settings)
+        mediator.play()
+        view.updateSettings(with: AppSettingModel.shared.getSettingsForOutput())
     }
 
-    // MARK: Monitor commands
-    @objc private func monitorCommands() {
-        mediator.monitorManualCommands()
-        ServiceManager.shared.send()
-        updateOutput()
-    }
-    
-    
-    // MARK: Stop commands
     func stopCommands() {
-        guard let t = updatingTimer else { return }
-        if t.isValid {
-            t.invalidate()
-        }
-
-        mediator.stopActiveCommands()
-        NetworkAdapter.shared.close()
+        mediator.stop()
     }
 
     func isCameraUsed() -> Bool {

--- a/ZIGSIMPlus/Presenters/CommandOutputPresenter.swift
+++ b/ZIGSIMPlus/Presenters/CommandOutputPresenter.swift
@@ -24,11 +24,9 @@ protocol CommandOutputPresenterDelegate: AnyObject {
 
 final class CommandOutputPresenter: CommandOutputPresenterProtocol {
     private weak var view: CommandOutputPresenterDelegate!
-    private var mediator: CommandAndServiceMediator
     
-    init(view: CommandOutputPresenterDelegate, mediator: CommandAndServiceMediator) {
+    init(view: CommandOutputPresenterDelegate) {
         self.view = view
-        self.mediator = mediator
 
         CommandPlayer.shared.onUpdate = {
             self.updateOutput()

--- a/ZIGSIMPlus/Presenters/CommandOutputPresenter.swift
+++ b/ZIGSIMPlus/Presenters/CommandOutputPresenter.swift
@@ -74,6 +74,7 @@ final class CommandOutputPresenter: CommandOutputPresenterProtocol {
         }
 
         mediator.stopActiveCommands()
+        NetworkAdapter.shared.close()
     }
 
     func isCameraUsed() -> Bool {

--- a/ZIGSIMPlus/Presenters/CommandSelectionPresenter.swift
+++ b/ZIGSIMPlus/Presenters/CommandSelectionPresenter.swift
@@ -25,12 +25,10 @@ protocol CommandSelectionPresenterDelegate: AnyObject {
 
 final class CommandSelectionPresenter: CommandSelectionPresenterProtocol {
     private weak var view: CommandSelectionPresenterDelegate!
-    private var mediator: CommandAndServiceMediator
     private var CommandToSelectArray: [CommandToSelect] = []
     
-    init(view: CommandSelectionPresenterDelegate, mediator: CommandAndServiceMediator) {
+    init(view: CommandSelectionPresenterDelegate) {
         self.view = view
-        self.mediator = mediator  
         updateCommandToSelectArray()
     }
     
@@ -98,7 +96,7 @@ final class CommandSelectionPresenter: CommandSelectionPresenterProtocol {
     private func updateCommandToSelectArray() {
         CommandToSelectArray = [CommandToSelect]()
         for command in Command.allCases {
-            CommandToSelectArray.append(CommandToSelect(labelString: command.rawValue, isAvailable: mediator.isAvailable(command)))
+            CommandToSelectArray.append(CommandToSelect(labelString: command.rawValue, isAvailable: CommandAndServiceMediator.isAvailable(command)))
         }
     }
 }

--- a/ZIGSIMPlus/Views/CommandOutputTabNavigationController.swift
+++ b/ZIGSIMPlus/Views/CommandOutputTabNavigationController.swift
@@ -9,25 +9,16 @@
 import UIKit
 
 class CommandOutputTabNavigationController: UINavigationController {
-    private var mediator: CommandAndServiceMediator?
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        if mediator == nil {
-            fatalError("CommandOutputTabNavigatorController.mediator is not initialized")
-        }
 
         // Initialize child view controllers
         for viewController in viewControllers {
             if type(of: viewController) == CommandOutputViewController.self {
                 let vc = viewController as! CommandOutputViewController
-                vc.presenter = CommandOutputPresenter(view: vc, mediator: mediator!)
+                vc.presenter = CommandOutputPresenter(view: vc)
             }
         }
-    }
-
-    func setMediator(_ mediator: CommandAndServiceMediator) {
-        self.mediator = mediator
     }
 }

--- a/ZIGSIMPlus/Views/CommandSelectionTabNavigationController.swift
+++ b/ZIGSIMPlus/Views/CommandSelectionTabNavigationController.swift
@@ -9,25 +9,16 @@
 import UIKit
 
 class CommandSelectionTabNavigationController: UINavigationController {
-    private var mediator: CommandAndServiceMediator?
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        if mediator == nil {
-            fatalError("CommandSelectionTabNavigatorController.mediator is not initialized")
-        }
 
         // Initialize child view controllers
         for viewController in viewControllers {
             if type(of: viewController) == CommandSelectionViewController.self {
                 let vc = viewController as! CommandSelectionViewController
-                vc.presenter = CommandSelectionPresenter(view: vc, mediator: mediator!)
+                vc.presenter = CommandSelectionPresenter(view: vc)
             }
         }
-    }
-
-    func setMediator(_ mediator: CommandAndServiceMediator) {
-        self.mediator = mediator
     }
 }

--- a/ZIGSIMPlus/Views/CommandSelectionViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSelectionViewController.swift
@@ -255,20 +255,19 @@ extension CommandSelectionViewController: UITableViewDataSource {
         } else {
           cell.checkMarkLavel.text = ""
         }
-        
-        let mediator = CommandAndServiceMediator()
-        if mediator.isAvailable(Command.allCases[indexPath.row]){
+
+        if CommandAndServiceMediator.isAvailable(Command.allCases[indexPath.row]){
             setAvailable(true, forCell:cell)
         } else {
             setAvailable(false, forCell:cell)
-            if mediator.isPremiumCommand(Command.allCases[indexPath.row]) && !presenter.isPremiumFeaturePurchased{
+            if CommandAndServiceMediator.isPremiumCommand(Command.allCases[indexPath.row]) && !presenter.isPremiumFeaturePurchased {
                 unAvailablePremiumCommands.append(Command.allCases[indexPath.row])
                 let orderedSet: NSOrderedSet = NSOrderedSet(array: unAvailablePremiumCommands)
                 unAvailablePremiumCommands = orderedSet.array as! [Command]
             }
         }
         
-        if !presenter.isPremiumFeaturePurchased && mediator.isPremiumCommand(Command.allCases[indexPath.row]){
+        if !presenter.isPremiumFeaturePurchased && CommandAndServiceMediator.isPremiumCommand(Command.allCases[indexPath.row]){
             setAvailable(false,forCell: cell)
         }
 

--- a/ZIGSIMPlus/Views/CommandSelectionViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSelectionViewController.swift
@@ -260,14 +260,14 @@ extension CommandSelectionViewController: UITableViewDataSource {
             setAvailable(true, forCell:cell)
         } else {
             setAvailable(false, forCell:cell)
-            if CommandAndServiceMediator.isPremiumCommand(Command.allCases[indexPath.row]) && !presenter.isPremiumFeaturePurchased {
+            if Command.allCases[indexPath.row].isPremium && !presenter.isPremiumFeaturePurchased {
                 unAvailablePremiumCommands.append(Command.allCases[indexPath.row])
                 let orderedSet: NSOrderedSet = NSOrderedSet(array: unAvailablePremiumCommands)
                 unAvailablePremiumCommands = orderedSet.array as! [Command]
             }
         }
         
-        if !presenter.isPremiumFeaturePurchased && CommandAndServiceMediator.isPremiumCommand(Command.allCases[indexPath.row]){
+        if !presenter.isPremiumFeaturePurchased && Command.allCases[indexPath.row].isPremium {
             setAvailable(false,forCell: cell)
         }
 


### PR DESCRIPTION
## Problem
The app crashes on sleep or on awake.
According to the error log, thee app dies because of signal 13 (SIGPIPE).

## Cause
SIGPIPE means the socket for TCP/UDP is broken.
ref. https://stackoverflow.com/questions/32197319/network-code-stopping-with-sigpipe

## Changes of this PR
- Add `CommandPlayer` 
  - Manages the state of command execution `playing`, `paused` or `stopped`.
- Make `CommandAndServiceMediator` methods static
  - This class has no properties now, so it doesn't need to be a Singleton.
- Fix bugs around sleep
  - Call `CommandPlayer.pause`/`resume` on device sleep/awake
  - `NetworkAdapter.close` is called inside