### PR TITLE
Fix osc address

### DIFF
--- a/ZIGSIMPlus.xcodeproj/project.pbxproj
+++ b/ZIGSIMPlus.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		021F240E22D39A580065D641 /* CommandPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021F240D22D39A580065D641 /* CommandPlayer.swift */; };
 		021F241022D3B16B0065D641 /* FileWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021F240F22D3B16B0065D641 /* FileWriter.swift */; };
 		021F241222D434F80065D641 /* SwiftOSCExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021F241122D434F80065D641 /* SwiftOSCExtension.swift */; };
+		021F241422D47DC60065D641 /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021F241322D47DC60065D641 /* Service.swift */; };
 		0236461B2298253900171F73 /* VideoCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023644AE2298253800171F73 /* VideoCaptureService.swift */; };
 		0236461C2298253900171F73 /* libndi_ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 023644BF2298253800171F73 /* libndi_ios.a */; };
 		0236461D2298253900171F73 /* NDI.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 023644C32298253800171F73 /* NDI.cpp */; };
@@ -112,6 +113,7 @@
 		021F240D22D39A580065D641 /* CommandPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPlayer.swift; sourceTree = "<group>"; };
 		021F240F22D3B16B0065D641 /* FileWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileWriter.swift; sourceTree = "<group>"; };
 		021F241122D434F80065D641 /* SwiftOSCExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftOSCExtension.swift; sourceTree = "<group>"; };
+		021F241322D47DC60065D641 /* Service.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
 		023644AE2298253800171F73 /* VideoCaptureService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoCaptureService.swift; sourceTree = "<group>"; };
 		023644B12298253800171F73 /* Processing.NDI.compat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Processing.NDI.compat.h; sourceTree = "<group>"; };
 		023644B22298253800171F73 /* Processing.NDI.utilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Processing.NDI.utilities.h; sourceTree = "<group>"; };
@@ -356,6 +358,7 @@
 				02A03595229CD56E00E7399E /* AudioLevelService.swift */,
 				02A03596229CD56E00E7399E /* ProximityService.swift */,
 				02A8FA872296B62D001FB3DD /* ServiceManager.swift */,
+				021F241322D47DC60065D641 /* Service.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -854,6 +857,7 @@
 				638345F422A6832700370600 /* NFCService.swift in Sources */,
 				026A3C3422BB831F0016DEF6 /* CommandOutputTabNavigationController.swift in Sources */,
 				902EB9CC227BE68D008F1650 /* CommandSelectionViewController.swift in Sources */,
+				021F241422D47DC60065D641 /* Service.swift in Sources */,
 				6345569C22B0E9150032E976 /* PresenterFactory.swift in Sources */,
 				B3CFE5B822ADF436009664C0 /* ModalTexts.swift in Sources */,
 				9092E4CA227D8ADF0019F1C1 /* CommandOutputViewController.swift in Sources */,

--- a/ZIGSIMPlus/Models/Services/AltimeterService.swift
+++ b/ZIGSIMPlus/Models/Services/AltimeterService.swift
@@ -93,15 +93,10 @@ extension AltimeterService : Service {
     }
 
     func toOSC() -> [OSCMessage] {
-        let deviceUUID = AppSettingModel.shared.deviceUUID
         var messages = [OSCMessage]()
 
         if AppSettingModel.shared.isActiveByCommand[Command.pressure]! {
-            messages.append(OSCMessage(
-                OSCAddressPattern("/\(deviceUUID)/pressure"),
-                pressureData,
-                altitudeData
-            ))
+            messages.append(osc("pressure", pressureData, altitudeData))
         }
 
         return messages

--- a/ZIGSIMPlus/Models/Services/AudioLevelService.swift
+++ b/ZIGSIMPlus/Models/Services/AudioLevelService.swift
@@ -131,15 +131,10 @@ extension AudioLevelService : Service {
     }
 
     func toOSC() -> [OSCMessage] {
-        let deviceUUID = AppSettingModel.shared.deviceUUID
         var data = [OSCMessage]()
 
         if AppSettingModel.shared.isActiveByCommand[Command.micLevel]! {
-            data.append(OSCMessage(
-                OSCAddressPattern("/\(deviceUUID)/miclevel"),
-                averageLevel,
-                maxLevel
-            ))
+            data.append(osc("miclevel", averageLevel, maxLevel))
         }
 
         return data

--- a/ZIGSIMPlus/Models/Services/BatteryService.swift
+++ b/ZIGSIMPlus/Models/Services/BatteryService.swift
@@ -60,11 +60,10 @@ extension BatteryService : Service {
     }
 
     func toOSC() -> [OSCMessage] {
-        let deviceUUID = AppSettingModel.shared.deviceUUID
         var messages = [OSCMessage]()
 
         if AppSettingModel.shared.isActiveByCommand[Command.battery]! {
-            messages.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/battery"), battery))
+            messages.append(osc("battery", battery))
         }
 
         return messages

--- a/ZIGSIMPlus/Models/Services/LocationService.swift
+++ b/ZIGSIMPlus/Models/Services/LocationService.swift
@@ -203,21 +203,20 @@ extension LocationService : Service {
     }
 
     func toOSC() -> [OSCMessage] {
-        let deviceUUID = AppSettingModel.shared.deviceUUID
         var data = [OSCMessage]()
 
         if AppSettingModel.shared.isActiveByCommand[Command.gps]! {
-            data.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/gps"), latitudeData, longitudeData))
+            data.append(osc("gps", latitudeData, longitudeData))
         }
 
         if AppSettingModel.shared.isActiveByCommand[Command.compass]! {
-            data.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/compass"), compassData, AppSettingModel.shared.compassOrientation.rawValue))
+            data.append(osc("compass", compassData, AppSettingModel.shared.compassOrientation.rawValue))
         }
 
         if AppSettingModel.shared.isActiveByCommand[Command.beacon]! {
             data += beacons.enumerated().map { (i, beacon)  in
-                return OSCMessage(
-                    OSCAddressPattern("/\(deviceUUID)/beacon\(i)"),
+                return osc(
+                    "beacon\(i)",
                     beacon.proximityUUID.uuidString,
                     beacon.major.intValue,
                     beacon.minor.intValue,

--- a/ZIGSIMPlus/Models/Services/MotionService.swift
+++ b/ZIGSIMPlus/Models/Services/MotionService.swift
@@ -108,44 +108,22 @@ extension MotionService : Service {
     }
 
     func toOSC() -> [OSCMessage] {
-        let deviceUUID = AppSettingModel.shared.deviceUUID
         var messages = [OSCMessage]()
 
         if AppSettingModel.shared.isActiveByCommand[Command.acceleration]! {
-            messages.append(OSCMessage(
-                OSCAddressPattern("/\(deviceUUID)/accel"),
-                accel.x,
-                accel.y,
-                accel.z
-            ))
+            messages.append(osc("accel", accel.x, accel.y, accel.z))
         }
 
         if AppSettingModel.shared.isActiveByCommand[Command.gravity]! {
-            messages.append(OSCMessage(
-                OSCAddressPattern("/\(deviceUUID)/gravity"),
-                gravity.x,
-                gravity.y,
-                gravity.z
-            ))
+            messages.append(osc("gravity", gravity.x, gravity.y, gravity.z))
         }
 
         if AppSettingModel.shared.isActiveByCommand[Command.gyro]! {
-            messages.append(OSCMessage(
-                OSCAddressPattern("/\(deviceUUID)/gyro"),
-                gyro.x,
-                gyro.y,
-                gyro.z
-            ))
+            messages.append(osc("gyro", gyro.x, gyro.y, gyro.z))
         }
 
         if AppSettingModel.shared.isActiveByCommand[Command.quaternion]! {
-            messages.append(OSCMessage(
-                OSCAddressPattern("/\(deviceUUID)/quaternion"),
-                quaternion.x,
-                quaternion.y,
-                quaternion.z,
-                quaternion.w
-            ))
+            messages.append(osc("quaternion", quaternion.x, quaternion.y, quaternion.z))
         }
 
         return messages

--- a/ZIGSIMPlus/Models/Services/ProximityService.swift
+++ b/ZIGSIMPlus/Models/Services/ProximityService.swift
@@ -59,11 +59,10 @@ extension ProximityService : Service {
     }
 
     func toOSC() -> [OSCMessage] {
-        let deviceUUID = AppSettingModel.shared.deviceUUID
         var data = [OSCMessage]()
 
         if AppSettingModel.shared.isActiveByCommand[Command.proximity]! {
-            data.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/proximitymonitor"), proximity))
+            data.append(osc("proximitymonitor", proximity))
         }
 
         return data

--- a/ZIGSIMPlus/Models/Services/RemoteControlService.swift
+++ b/ZIGSIMPlus/Models/Services/RemoteControlService.swift
@@ -122,12 +122,11 @@ extension RemoteControlService : Service {
     }
 
     func toOSC() -> [OSCMessage] {
-        let deviceUUID = AppSettingModel.shared.deviceUUID
         var messages = [OSCMessage]()
 
         if AppSettingModel.shared.isActiveByCommand[Command.remoteControl]! {
-            messages.append(OSCMessage(
-                OSCAddressPattern("/\(deviceUUID)/remotecontrol"),
+            messages.append(osc(
+                "remotecontrol",
                 playPauseChanged,
                 volumeUp,
                 volumeDown,

--- a/ZIGSIMPlus/Models/Services/Service.swift
+++ b/ZIGSIMPlus/Models/Services/Service.swift
@@ -1,0 +1,24 @@
+//
+//  Service.swift
+//  ZIGSIMPlus
+//
+//  Created by Takayosi Amagi on 2019/07/09.
+//  Copyright © 2019 1→10, Inc. All rights reserved.
+//
+
+import Foundation
+import SwiftOSC
+import SwiftyJSON
+
+protocol Service {
+    func toLog() -> [String]
+    func toOSC() -> [OSCMessage]
+    func toJSON() throws -> JSON
+}
+
+extension Service {
+    func osc(_ address: String, _ args: OSCType?...) -> OSCMessage {
+        let deviceUUID = AppSettingModel.shared.deviceUUID
+        return OSCMessage(OSCAddressPattern("/ZIGSIM/\(deviceUUID)/\(address)"), args)
+    }
+}

--- a/ZIGSIMPlus/Models/Services/ServiceManager.swift
+++ b/ZIGSIMPlus/Models/Services/ServiceManager.swift
@@ -17,6 +17,13 @@ protocol Service {
     func toJSON() throws -> JSON
 }
 
+extension Service {
+    func osc(_ address: String, _ args: OSCType?...) -> OSCMessage {
+        let deviceUUID = AppSettingModel.shared.deviceUUID
+        return OSCMessage(OSCAddressPattern("/\(deviceUUID)/\(address)"), args)
+    }
+}
+
 /// ServiceManager creates OSC / JSON data.
 /// It also creates single string for output view.
 ///

--- a/ZIGSIMPlus/Models/Services/ServiceManager.swift
+++ b/ZIGSIMPlus/Models/Services/ServiceManager.swift
@@ -11,19 +11,6 @@ import SwiftOSC
 import SwiftyJSON
 import DeviceKit
 
-protocol Service {
-    func toLog() -> [String]
-    func toOSC() -> [OSCMessage]
-    func toJSON() throws -> JSON
-}
-
-extension Service {
-    func osc(_ address: String, _ args: OSCType?...) -> OSCMessage {
-        let deviceUUID = AppSettingModel.shared.deviceUUID
-        return OSCMessage(OSCAddressPattern("/ZIGSIM/\(deviceUUID)/\(address)"), args)
-    }
-}
-
 /// ServiceManager creates OSC / JSON data.
 /// It also creates single string for output view.
 ///

--- a/ZIGSIMPlus/Models/Services/ServiceManager.swift
+++ b/ZIGSIMPlus/Models/Services/ServiceManager.swift
@@ -20,7 +20,7 @@ protocol Service {
 extension Service {
     func osc(_ address: String, _ args: OSCType?...) -> OSCMessage {
         let deviceUUID = AppSettingModel.shared.deviceUUID
-        return OSCMessage(OSCAddressPattern("/\(deviceUUID)/\(address)"), args)
+        return OSCMessage(OSCAddressPattern("/ZIGSIM/\(deviceUUID)/\(address)"), args)
     }
 }
 

--- a/ZIGSIMPlus/Models/Services/TouchService.swift
+++ b/ZIGSIMPlus/Models/Services/TouchService.swift
@@ -168,24 +168,24 @@ extension TouchService : Service {
 
             if isTouchActive {
                 // Position
-                messages.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/touch\(i)1"), Float(point.x)))
-                messages.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/touch\(i)2"), Float(point.y)))
+                messages.append(osc("touch\(i)1", Float(point.x)))
+                messages.append(osc("touch\(i)2", Float(point.y)))
 
                 if #available(iOS 8.0, *) {
-                    messages.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/touchradius\(i)"), Float(touch.majorRadius)))
+                    messages.append(osc("touchradius\(i)", Float(touch.majorRadius)))
                 }
                 if #available(iOS 9.0, *) {
-                    messages.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/touchforce\(i)"), Float(touch.force)))
+                    messages.append(osc("touchforce\(i)", Float(touch.force)))
                 }
             }
 
             if isApplePencilActive && touch.type == .pencil {
-                messages.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/penciltouch\(i)1"), Float(point.x)))
-                messages.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/penciltouch\(i)2"), Float(point.y)))
-                messages.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/pencilaltitude\(i)"), Float(touch.altitudeAngle)))
-                messages.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/pencilazimuth\(i)"), Float(touch.azimuthAngle(in: touch.view!))))
+                messages.append(osc("penciltouch\(i)1", Float(point.x)))
+                messages.append(osc("penciltouch\(i)2", Float(point.y)))
+                messages.append(osc("pencilaltitude\(i)", Float(touch.altitudeAngle)))
+                messages.append(osc("pencilazimuth\(i)", Float(touch.azimuthAngle(in: touch.view!))))
                 if #available(iOS 9.0, *) {
-                    messages.append(OSCMessage(OSCAddressPattern("/\(deviceUUID)/pencilforce\(i)"), Float(touch.force)))
+                    messages.append(osc("pencilforce\(i)", Float(touch.force)))
                 }
             }
         }

--- a/ZIGSIMPlus/Utils.swift
+++ b/ZIGSIMPlus/Utils.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import UIKit
-import SwiftOSC
 
 class Utils {
     static func randomStringWithLength(_ length: Int) -> String {

--- a/ZIGSIMPlus/Utils.swift
+++ b/ZIGSIMPlus/Utils.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import UIKit
+import SwiftOSC
 
 class Utils {
     static func randomStringWithLength(_ length: Int) -> String {


### PR DESCRIPTION
In old ZIG SIM, every OSC message had prefix `/ZIGSIM` in the address... 😇 

## Changes
- Add `/ZIGSIM` prefix to OSC addresses
- Add `Service.osc` to make OSC messages