### PR TITLE
Fix communication format

### DIFF
--- a/ZIGSIMPlus/Models/Services/AudioLevelService.swift
+++ b/ZIGSIMPlus/Models/Services/AudioLevelService.swift
@@ -134,7 +134,7 @@ extension AudioLevelService : Service {
         var data = [OSCMessage]()
 
         if AppSettingModel.shared.isActiveByCommand[Command.micLevel]! {
-            data.append(osc("miclevel", averageLevel, maxLevel))
+            data.append(osc("miclevel", maxLevel, averageLevel))
         }
 
         return data

--- a/ZIGSIMPlus/Models/Services/ProximityService.swift
+++ b/ZIGSIMPlus/Models/Services/ProximityService.swift
@@ -62,7 +62,7 @@ extension ProximityService : Service {
         var data = [OSCMessage]()
 
         if AppSettingModel.shared.isActiveByCommand[Command.proximity]! {
-            data.append(osc("proximitymonitor", proximity))
+            data.append(osc("proximitymonitor", proximity ? 1 : 0))
         }
 
         return data


### PR DESCRIPTION
# 変更点
 - proximityコマンドのosc通信での送信値を旧ZIGSIMに合わせた。
 - Mic levelコマンドのosc通信での送信値`max`と`average`の順序を旧ZIGSIMに合わせた。