### PR TITLE
fix mic fps,delete unnecessary process

### DIFF
--- a/ZIGSIMPlus/Models/Services/AudioLevelService.swift
+++ b/ZIGSIMPlus/Models/Services/AudioLevelService.swift
@@ -98,7 +98,7 @@ class AudioLevelService {
         // Enable level meter
         var enabledLevelMeter: UInt32 = 1
         AudioQueueSetProperty(self.queue, kAudioQueueProperty_EnableLevelMetering, &enabledLevelMeter, UInt32(MemoryLayout<UInt32>.size))
-        self.timer = Timer.scheduledTimer(timeInterval: 1.0 / fps,
+        self.timer = Timer.scheduledTimer(timeInterval: fps,
                                           target: self,
                                           selector: #selector(AudioLevelService.detectVolume(timer:)),
                                           userInfo: nil,

--- a/ZIGSIMPlus/Models/Services/LocationService.swift
+++ b/ZIGSIMPlus/Models/Services/LocationService.swift
@@ -172,13 +172,6 @@ extension LocationService : Service {
     func toLog() -> [String] {
         var log = [String]()
 
-        var stringMsg = ""
-
-        for (i, b) in beacons.enumerated() {
-            stringMsg += "Beacon \(i): uuid:\(b.proximityUUID.uuidString) major:\(b.major.intValue) minor:\(b.minor.intValue) rssi:\(b.rssi)\n"
-        }
-
-
         if AppSettingModel.shared.isActiveByCommand[Command.gps]! {
             log += [
                 "gps:latitude:\(latitudeData)",


### PR DESCRIPTION
# 変更点
 - AudioLevelServiceのtimeIntervalの値
 - beaconのログ周りで使ってなさそうな処理を削除　← amagiさん、こちら消してしまって大丈夫でしょうか？