### PR TITLE
fix detail button available

### DIFF
--- a/ZIGSIMPlus/Views/CommandSelectionViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSelectionViewController.swift
@@ -278,6 +278,7 @@ extension CommandSelectionViewController: UITableViewDataSource {
     
     func setAvailable(_ isAvailable: Bool, forCell cell: StandardCell?) {
         cell?.commandOnOffButton.isEnabled = isAvailable
+        cell?.detailButton.isEnabled = isAvailable
         if isAvailable {
             cell?.commandLabel.textColor = Theme.main
             cell?.detailButton.tintColor = Theme.main


### PR DESCRIPTION
# 変更点
 - 課金前に課金コマンドの詳細ボタンを選択できていたので、選択できないように修正