### PR TITLE
Fix apple pencil premium & add classification by device

### DIFF
--- a/ZIGSIMPlus/Entities/Command.swift
+++ b/ZIGSIMPlus/Entities/Command.swift
@@ -56,7 +56,7 @@ public enum Command: String, CaseIterable {
 
     var isPremium: Bool {
         switch self {
-        case .ndi, .arkit, .imageDetection, .nfc, .applePencil:
+        case .ndi, .arkit, .imageDetection, .nfc:
             return true
         default:
             return false

--- a/ZIGSIMPlus/Entities/PremiumText.swift
+++ b/ZIGSIMPlus/Entities/PremiumText.swift
@@ -11,6 +11,4 @@ import Foundation
 let premiumTextTitle: String = "Explore more with premium features"
 let premiumTextBody: String = """
 You have to purchase to unlock these functions.
-
-Note that Apple Pencil function only works on Apple Pencil compatible devices, that are some of iPad models.
 """

--- a/ZIGSIMPlus/Models/AppSettingModel.swift
+++ b/ZIGSIMPlus/Models/AppSettingModel.swift
@@ -106,11 +106,6 @@ enum SettingViewTextType {
     case deviceUuid
 }
 
-enum DeviceModel: String {
-    case iphone = "iPhone"
-    case ipad = "iPad"
-}
-
 public class AppSettingModel {
     private init() {
         for command in Command.allCases {

--- a/ZIGSIMPlus/Models/AppSettingModel.swift
+++ b/ZIGSIMPlus/Models/AppSettingModel.swift
@@ -106,6 +106,11 @@ enum SettingViewTextType {
     case deviceUuid
 }
 
+enum DeviceModel: String {
+    case iphone = "iPhone"
+    case ipad = "iPad"
+}
+
 public class AppSettingModel {
     private init() {
         for command in Command.allCases {

--- a/ZIGSIMPlus/Models/CommandAndServiceMediator.swift
+++ b/ZIGSIMPlus/Models/CommandAndServiceMediator.swift
@@ -18,8 +18,10 @@ public class CommandAndServiceMediator {
         switch command {
         case .acceleration, .gravity, .gyro, .quaternion:
             return MotionService.shared.isAvailable()
-        case .touch, .applePencil:
-            return TouchService.shared.isAvailable()
+        case .touch:
+            return TouchService.shared.isTouchAvailable()
+        case .applePencil:
+            return TouchService.shared.isApplePencilAvailable()
         case .battery:
             return BatteryService.shared.isAvailable()
         case .compass, .gps, .beacon:

--- a/ZIGSIMPlus/Models/Services/TouchService.swift
+++ b/ZIGSIMPlus/Models/Services/TouchService.swift
@@ -35,10 +35,7 @@ public class TouchService {
     }
 
     func isApplePencilAvailable() -> Bool {
-        if Device().model == DeviceModel.ipad.rawValue {
-            return true
-        }
-        return false
+        return Device().isPad
     }
 
     func enable() {

--- a/ZIGSIMPlus/Models/Services/TouchService.swift
+++ b/ZIGSIMPlus/Models/Services/TouchService.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 1→10, Inc. All rights reserved.
 //
 
+import DeviceKit
 import Foundation
 import SwiftOSC
 import SwiftyJSON
@@ -29,8 +30,15 @@ public class TouchService {
 
     // MARK: - Public methods
 
-    func isAvailable() -> Bool {
+    func isTouchAvailable() -> Bool {
         return true
+    }
+
+    func isApplePencilAvailable() -> Bool {
+        if Device().model == DeviceModel.ipad.rawValue {
+            return true
+        }
+        return false
     }
 
     func enable() {

--- a/ZIGSIMPlus/Views/CommandSelectionViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSelectionViewController.swift
@@ -152,7 +152,7 @@ final class CommandSelectionViewController: UIViewController {
     }
 
     private func adjustLockPremiumFeatureLabel() {
-        lockPremiumFeatureLabel.frame = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.size.width, height: 44 * 5)
+        lockPremiumFeatureLabel.frame = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.size.width, height: 44 * 4)
         lockPremiumFeatureLabel.backgroundColor = Theme.overlay
     }
 


### PR DESCRIPTION
以下を修正しました。
## apple pencilコマンドを課金対象から除外
* https://github.com/1-10/ZIGSIMPlus_iOS_Public/commit/84211af610acde4ffbf6022a8a7a317a29caf453
* https://github.com/1-10/ZIGSIMPlus_iOS_Public/commit/a1a873be610b515d612c12b7199713de25d1cb71
* https://github.com/1-10/ZIGSIMPlus_iOS_Public/commit/93b3a122ae7f573b901e48d0bc766d2076e5c287

## デバイスがiPhoneの場合でもapple pencilコマンドが選択できていたので修正
* https://github.com/1-10/ZIGSIMPlus_iOS_Public/commit/a6d6e478b34dc70fd2ee3b1f6088783fa475d24d

## 画面イメージ
* iPhone  
![iphone](https://user-images.githubusercontent.com/44634617/64510450-30ef1d00-d31d-11e9-94a5-bb460b8e3fbb.gif)

* iPad  
![ipad](https://user-images.githubusercontent.com/44634617/64510490-4106fc80-d31d-11e9-90b0-1e8d139c68bb.gif)
