### PR TITLE
Ignore Darkmode

### DIFF
--- a/ZIGSIMPlus/Info.plist
+++ b/ZIGSIMPlus/Info.plist
@@ -54,5 +54,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>UIUserInterfaceStyle</key>
+	<string>LIGHT</string>
 </dict>
 </plist>


### PR DESCRIPTION
As ZIGSIM Pro has dark UI by default, we can ignore darkmode settings of iOS.
In this PR, simply add `UserInterfaceStyle` value to Info.plist to avoid applying darkmode to the app UI.
See https://qiita.com/wanaringo/items/3811cea60d7ba815dd84#infoplist%E3%81%ABuser-interface-style%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%99%E3%82%8B
