### PR TITLE
Fix remote control

### DIFF
--- a/ZIGSIMPlus.xcodeproj/project.pbxproj
+++ b/ZIGSIMPlus.xcodeproj/project.pbxproj
@@ -1139,7 +1139,7 @@
 					"$(PROJECT_DIR)/Private/Prototypes/NDISwift/ofxNDI/libs/NDI/lib/ios",
 					"$(PROJECT_DIR)/Private/VideoCapture/SDK/lib",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				MTLLINKER_FLAGS = "-cikernel";
 				MTL_COMPILER_FLAGS = "-fcikernel";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.1-10.ZIG-SIM-PRO";
@@ -1184,7 +1184,7 @@
 					"$(PROJECT_DIR)/Private/Prototypes/NDISwift/ofxNDI/libs/NDI/lib/ios",
 					"$(PROJECT_DIR)/Private/VideoCapture/SDK/lib",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 1.4.1;
 				MTLLINKER_FLAGS = "-cikernel";
 				MTL_COMPILER_FLAGS = "-fcikernel";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.1-10.ZIG-SIM-PRO";

--- a/ZIGSIMPlus/Models/Services/RemoteControlService.swift
+++ b/ZIGSIMPlus/Models/Services/RemoteControlService.swift
@@ -45,8 +45,9 @@ public class RemoteControlService: NSObject {
         volume = notification.userInfo!["AVSystemController_AudioVolumeNotificationParameter"] as! Double
     }
 
-    @objc func onTogglePlayPause(_ event: MPRemoteCommandEvent) {
+    @objc func onTogglePlayPause(_ event: MPRemoteCommandEvent) -> MPRemoteCommandHandlerStatus {
         isPlaying.toggle()
+        return .success
     }
 
     // MARK: - Internal methods


### PR DESCRIPTION
## Purpose of this fix
- To fix this issue (https://github.com/1-10/ZIGSIMPlus_iOS_Public/issues/109).

## Reason of the issue
- It doesn't seem to matter whether iPhone equipped an earphone socket or not.
  - ref: https://developer.apple.com/forums/thread/121540 


## Changes
- I changed the action function of togglePlayPauseCommand in MPRemoteCommandCenter to return Status.
