### PR TITLE
fix: remove iOS 13 availability guard and migrate ServiceManager to OSCKit

### DIFF
--- a/ZIGSIMPlus/Models/Services/ServiceManager.swift
+++ b/ZIGSIMPlus/Models/Services/ServiceManager.swift
@@ -8,7 +8,7 @@
 
 import DeviceKit
 import Foundation
-import SwiftOSC
+import OSCKit
 import SwiftyJSON
 
 /// ServiceManager creates OSC / JSON data.
@@ -27,7 +27,7 @@ class ServiceManager {
 
         if AppSettingModel.shared.transportFormat == .OSC {
             let osc = getOSC()
-            data = osc.data
+            data = (try? OSCPacket.bundle(osc).rawData()) ?? Data()
         } else {
             let json = getJSON()
             data = try! json.rawData() // swiftlint:disable:this force_try
@@ -63,33 +63,35 @@ class ServiceManager {
     }
 
     public func getOSC() -> OSCBundle {
-        let bundle = OSCBundle()
+        var bundle = OSCBundle()
         let device = Device.current
 
         // Default data
         let settings = AppSettingModel.shared
-        bundle.add(OSCMessage(
-            OSCAddressPattern("/\(settings.deviceUUID)/deviceinfo"),
-            device.description,
-            settings.deviceUUID,
-            "ios",
-            device.systemVersion,
-            Int(Utils.screenWidth),
-            Int(Utils.screenHeight)
-        ))
+        bundle.elements.append(.message(OSCMessage(
+            "/\(settings.deviceUUID)/deviceinfo",
+            values: [
+                device.description,
+                settings.deviceUUID,
+                "ios",
+                device.systemVersion ?? "",
+                Int(Utils.screenWidth),
+                Int(Utils.screenHeight),
+            ]
+        )))
 
         // Add data from stores
-        bundle.elements += AltimeterService.shared.toOSC()
-        bundle.elements += ArkitService.shared.toOSC()
-        bundle.elements += AudioLevelService.shared.toOSC()
-        bundle.elements += LocationService.shared.toOSC()
-        bundle.elements += MotionService.shared.toOSC()
-        bundle.elements += BatteryService.shared.toOSC()
-        bundle.elements += ProximityService.shared.toOSC()
-        bundle.elements += RemoteControlService.shared.toOSC()
-        bundle.elements += TouchService.shared.toOSC()
-        bundle.elements += VideoCaptureService.shared.toOSC()
-        bundle.elements += NFCService.shared.toOSC()
+        bundle.elements += AltimeterService.shared.toOSC().map { .message($0) }
+        bundle.elements += ArkitService.shared.toOSC().map { .message($0) }
+        bundle.elements += AudioLevelService.shared.toOSC().map { .message($0) }
+        bundle.elements += LocationService.shared.toOSC().map { .message($0) }
+        bundle.elements += MotionService.shared.toOSC().map { .message($0) }
+        bundle.elements += BatteryService.shared.toOSC().map { .message($0) }
+        bundle.elements += ProximityService.shared.toOSC().map { .message($0) }
+        bundle.elements += RemoteControlService.shared.toOSC().map { .message($0) }
+        bundle.elements += TouchService.shared.toOSC().map { .message($0) }
+        bundle.elements += VideoCaptureService.shared.toOSC().map { .message($0) }
+        bundle.elements += NFCService.shared.toOSC().map { .message($0) }
 
         // TODO: Add timetag
 

--- a/ZIGSIMPlus/Views/CommandSettingViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSettingViewController.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2019 1→10, Inc. All rights reserved.
 //
 import Foundation
-import SVProgressHUD
 import UIKit
 
 protocol ContentScrollable {
@@ -52,12 +51,10 @@ public class CommandSettingViewController: UIViewController {
                 segment.selectedSegmentIndex = userDefaultSegments[.messageRatePerSecond] ?? 0
             }
             // Because the specification of UISegmentedControl has changed from iOS13
-            if #available(iOS 13.0, *) {
-                segment.selectedSegmentTintColor = Theme.main
-                segment.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: Theme.main], for: .normal)
-                segment.layer.borderWidth = 1
-                segment.layer.borderColor = Theme.main.cgColor
-            }
+            segment.selectedSegmentTintColor = Theme.main
+            segment.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: Theme.main], for: .normal)
+            segment.layer.borderWidth = 1
+            segment.layer.borderColor = Theme.main.cgColor
         }
 
         initNavigationBar()


### PR DESCRIPTION
## Summary

- `CommandSettingViewController.swift` の `if #available(iOS 13.0, *)` デッドコードを除去（Issue #121）
- `ServiceManager.swift` の `SwiftOSC` → `OSCKit` 移行（ビルドエラー修正）

## Changes

### Issue #121: `#available(iOS 13.0, *)` 除去
- `CommandSettingViewController.swift` L54–60 の条件分岐を展開・削除
- プロジェクト最低対応 OS は iOS 15 のため、条件は常に true であり `else` ブランチは到達不能だった

### ServiceManager SwiftOSC → OSCKit 移行（ビルド修正）
- `import SwiftOSC` → `import OSCKit`
- `osc.data` → `OSCPacket.bundle(osc).rawData()`
- `bundle.add(OSCMessage(OSCAddressPattern(...), ...))` → OSCKit スタイルに変更
- `bundle.elements += service.toOSC()` → `.map { .message($0) }` でラップ（`[OSCMessage]` → `[OSCPacket]`）
- `device.systemVersion`（`String?`）をアンラップ

## Test plan

- [ ] ビルド成功確認（`xcodebuild` でエラーなし）
- [ ] シミュレータで設定画面を開き、`UISegmentedControl` のスタイルが崩れていないことを確認
- [ ] OSC 送信が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)