### PR TITLE
Refactor TouchService shared touch payload handling

### DIFF
--- a/ZIGSIMPlus/Models/Services/TouchService.swift
+++ b/ZIGSIMPlus/Models/Services/TouchService.swift
@@ -8,7 +8,7 @@
 
 import DeviceKit
 import Foundation
-import SwiftOSC
+import OSCKit
 import SwiftyJSON
 import UIKit
 

--- a/ZIGSIMPlus/Models/Services/TouchService.swift
+++ b/ZIGSIMPlus/Models/Services/TouchService.swift
@@ -8,12 +8,26 @@
 
 import DeviceKit
 import Foundation
-import SwiftOSC
+import OSCKit
 import SwiftyJSON
 import UIKit
 
 /// Data store for touch data.
 public class TouchService {
+    private struct TouchCommandSettings {
+        let isTouchActive: Bool
+        let isApplePencilActive: Bool
+    }
+
+    private struct TouchPayload {
+        let point: CGPoint
+        let radius: CGFloat
+        let force: CGFloat
+        let altitudeAngle: CGFloat
+        let azimuthAngle: CGFloat
+        let isPencil: Bool
+    }
+
     // Singleton instance
     static let shared = TouchService()
 
@@ -85,52 +99,35 @@ public class TouchService {
         touchArea = rect
     }
 
-    private func getTouchResult(from touches: [UITouch]) -> [String] {
+    private func commandSettings() -> TouchCommandSettings? {
         guard let isTouchActive = AppSettingModel.shared.isActiveByCommand[Command.touch],
             let isApplePencilActive = AppSettingModel.shared.isActiveByCommand[Command.applePencil]
         else {
-            fatalError("AppSetting for the command is nil")
+            return nil
         }
 
-        var result = [String]()
+        return TouchCommandSettings(
+            isTouchActive: isTouchActive,
+            isApplePencilActive: isApplePencilActive
+        )
+    }
 
-        for touch in touches {
-            var point = touch.location(in: touch.view!)
-            point = remapToScreenCoord(point)
-
-            if isTouchActive {
-                // Position
-                result += [
-                    String(format: "touch:x:%.3f", point.x),
-                    String(format: "touch:y:%.3f", point.y),
-                ]
-
-                // touch radius
-                if #available(iOS 8.0, *) {
-                    result.append(String(format: "touch:radius:%.3f", touch.majorRadius))
-                }
-
-                // 3d touch
-                if #available(iOS 9.0, *) {
-                    result.append(String(format: "touch:force:%.3f", touch.force))
-                }
+    private func touchPayloads(from touches: [UITouch]) -> [TouchPayload] {
+        return touches.compactMap { touch in
+            guard let view = touch.view else {
+                return nil
             }
 
-            if isApplePencilActive, touch.type == .pencil {
-                result += [
-                    "pencil:touch:x:\(point.x)",
-                    "pencil:touch:y:\(point.y)",
-                    "pencil:altitude:\(touch.altitudeAngle)",
-                    "pencil:azimuth:\(touch.azimuthAngle(in: touch.view!))",
-                ]
-
-                if #available(iOS 9.0, *) {
-                    result.append(String(format: "pencil:force:%.3f", touch.force))
-                }
-            }
+            let point = remapToScreenCoord(touch.location(in: view))
+            return TouchPayload(
+                point: point,
+                radius: touch.majorRadius,
+                force: touch.force,
+                altitudeAngle: touch.altitudeAngle,
+                azimuthAngle: touch.azimuthAngle(in: view),
+                isPencil: touch.type == .pencil
+            )
         }
-
-        return result
     }
 
     // Remap values to range [-1, 1]
@@ -146,47 +143,62 @@ public class TouchService {
 
 extension TouchService: Service {
     func toLog() -> [String] {
-        return getTouchResult(from: touchPoints)
+        guard let settings = commandSettings() else {
+            return []
+        }
+
+        var result = [String]()
+
+        for payload in touchPayloads(from: touchPoints) {
+            if settings.isTouchActive {
+                result += [
+                    String(format: "touch:x:%.3f", payload.point.x),
+                    String(format: "touch:y:%.3f", payload.point.y),
+                    String(format: "touch:radius:%.3f", payload.radius),
+                    String(format: "touch:force:%.3f", payload.force),
+                ]
+            }
+
+            if settings.isApplePencilActive, payload.isPencil {
+                result += [
+                    "pencil:touch:x:\(payload.point.x)",
+                    "pencil:touch:y:\(payload.point.y)",
+                    "pencil:altitude:\(payload.altitudeAngle)",
+                    "pencil:azimuth:\(payload.azimuthAngle)",
+                    String(format: "pencil:force:%.3f", payload.force),
+                ]
+            }
+        }
+
+        return result
     }
 
     func toOSC() -> [OSCMessage] {
-        guard let isTouchActive = AppSettingModel.shared.isActiveByCommand[Command.touch],
-            let isApplePencilActive = AppSettingModel.shared.isActiveByCommand[Command.applePencil]
-        else {
-            fatalError("AppSetting for the command is nil")
+        guard let settings = commandSettings() else {
+            return []
         }
 
-        if !isTouchActive, !isApplePencilActive {
+        if !settings.isTouchActive, !settings.isApplePencilActive {
             return []
         }
 
         var messages = [OSCMessage]()
 
-        for (i, touch) in touchPoints.enumerated() {
-            var point = touch.location(in: touch.view!)
-            point = remapToScreenCoord(point)
-
-            if isTouchActive {
+        for (i, payload) in touchPayloads(from: touchPoints).enumerated() {
+            if settings.isTouchActive {
                 // Position
-                messages.append(osc("touch\(i)1", Float(point.x)))
-                messages.append(osc("touch\(i)2", Float(point.y)))
-
-                if #available(iOS 8.0, *) {
-                    messages.append(osc("touchradius\(i)", Float(touch.majorRadius)))
-                }
-                if #available(iOS 9.0, *) {
-                    messages.append(osc("touchforce\(i)", Float(touch.force)))
-                }
+                messages.append(osc("touch\(i)1", Float(payload.point.x)))
+                messages.append(osc("touch\(i)2", Float(payload.point.y)))
+                messages.append(osc("touchradius\(i)", Float(payload.radius)))
+                messages.append(osc("touchforce\(i)", Float(payload.force)))
             }
 
-            if isApplePencilActive, touch.type == .pencil {
-                messages.append(osc("penciltouch\(i)1", Float(point.x)))
-                messages.append(osc("penciltouch\(i)2", Float(point.y)))
-                messages.append(osc("pencilaltitude\(i)", Float(touch.altitudeAngle)))
-                messages.append(osc("pencilazimuth\(i)", Float(touch.azimuthAngle(in: touch.view!))))
-                if #available(iOS 9.0, *) {
-                    messages.append(osc("pencilforce\(i)", Float(touch.force)))
-                }
+            if settings.isApplePencilActive, payload.isPencil {
+                messages.append(osc("penciltouch\(i)1", Float(payload.point.x)))
+                messages.append(osc("penciltouch\(i)2", Float(payload.point.y)))
+                messages.append(osc("pencilaltitude\(i)", Float(payload.altitudeAngle)))
+                messages.append(osc("pencilazimuth\(i)", Float(payload.azimuthAngle)))
+                messages.append(osc("pencilforce\(i)", Float(payload.force)))
             }
         }
 
@@ -194,48 +206,34 @@ extension TouchService: Service {
     }
 
     func toJSON() throws -> JSON {
-        guard let isTouchActive = AppSettingModel.shared.isActiveByCommand[Command.touch],
-            let isApplePencilActive = AppSettingModel.shared.isActiveByCommand[Command.applePencil]
-        else {
-            fatalError("AppSetting for the command is nil")
+        guard let settings = commandSettings() else {
+            return JSON()
         }
+
         var data = JSON()
+        let payloads = touchPayloads(from: touchPoints)
 
-        if isTouchActive {
-            let touchData: [[String: CGFloat]] = touchPoints.map { touch in
-                var point = touch.location(in: touch.view!)
-                point = remapToScreenCoord(point)
-
-                var obj = ["x": point.x, "y": point.y]
-
-                if #available(iOS 8.0, *) {
-                    obj["radius"] = touch.majorRadius
-                }
-                if #available(iOS 9.0, *) {
-                    obj["force"] = touch.force
-                }
-
-                return obj
+        if settings.isTouchActive {
+            let touchData: [[String: CGFloat]] = payloads.map { payload in
+                return [
+                    "x": payload.point.x,
+                    "y": payload.point.y,
+                    "radius": payload.radius,
+                    "force": payload.force,
+                ]
             }
             data["touch"] = JSON(touchData)
         }
 
-        if isApplePencilActive {
-            let pencilData: [[String: CGFloat]] = touchPoints.map { touch in
-                var point = touch.location(in: touch.view!)
-                point = remapToScreenCoord(point)
-
-                var obj = [
-                    "x": point.x,
-                    "y": point.y,
-                    "altitude": touch.altitudeAngle,
-                    "azimuth": touch.azimuthAngle(in: touch.view!),
+        if settings.isApplePencilActive {
+            let pencilData: [[String: CGFloat]] = payloads.map { payload in
+                return [
+                    "x": payload.point.x,
+                    "y": payload.point.y,
+                    "altitude": payload.altitudeAngle,
+                    "azimuth": payload.azimuthAngle,
+                    "force": payload.force,
                 ]
-                if #available(iOS 9.0, *) {
-                    obj["force"] = touch.force
-                }
-
-                return obj
             }
             data["pencil"] = JSON(pencilData)
         }

--- a/ZIGSIMPlus/Models/Services/TouchService.swift
+++ b/ZIGSIMPlus/Models/Services/TouchService.swift
@@ -8,7 +8,7 @@
 
 import DeviceKit
 import Foundation
-import OSCKit
+import SwiftOSC
 import SwiftyJSON
 import UIKit
 
@@ -112,22 +112,20 @@ public class TouchService {
         )
     }
 
-    private func touchPayloads(from touches: [UITouch]) -> [TouchPayload] {
-        return touches.compactMap { touch in
-            guard let view = touch.view else {
-                return nil
-            }
-
-            let point = remapToScreenCoord(touch.location(in: view))
-            return TouchPayload(
-                point: point,
-                radius: touch.majorRadius,
-                force: touch.force,
-                altitudeAngle: touch.altitudeAngle,
-                azimuthAngle: touch.azimuthAngle(in: view),
-                isPencil: touch.type == .pencil
-            )
+    private func touchPayload(for touch: UITouch) -> TouchPayload? {
+        guard let view = touch.view else {
+            return nil
         }
+
+        let point = remapToScreenCoord(touch.location(in: view))
+        return TouchPayload(
+            point: point,
+            radius: touch.majorRadius,
+            force: touch.force,
+            altitudeAngle: touch.altitudeAngle,
+            azimuthAngle: touch.azimuthAngle(in: view),
+            isPencil: touch.type == .pencil
+        )
     }
 
     // Remap values to range [-1, 1]
@@ -149,7 +147,11 @@ extension TouchService: Service {
 
         var result = [String]()
 
-        for payload in touchPayloads(from: touchPoints) {
+        for touch in touchPoints {
+            guard let payload = touchPayload(for: touch) else {
+                continue
+            }
+
             if settings.isTouchActive {
                 result += [
                     String(format: "touch:x:%.3f", payload.point.x),
@@ -184,7 +186,11 @@ extension TouchService: Service {
 
         var messages = [OSCMessage]()
 
-        for (i, payload) in touchPayloads(from: touchPoints).enumerated() {
+        for (i, touch) in touchPoints.enumerated() {
+            guard let payload = touchPayload(for: touch) else {
+                continue
+            }
+
             if settings.isTouchActive {
                 // Position
                 messages.append(osc("touch\(i)1", Float(payload.point.x)))
@@ -211,10 +217,12 @@ extension TouchService: Service {
         }
 
         var data = JSON()
-        let payloads = touchPayloads(from: touchPoints)
-
         if settings.isTouchActive {
-            let touchData: [[String: CGFloat]] = payloads.map { payload in
+            let touchData: [[String: CGFloat]] = touchPoints.compactMap { touch in
+                guard let payload = touchPayload(for: touch) else {
+                    return nil
+                }
+
                 return [
                     "x": payload.point.x,
                     "y": payload.point.y,
@@ -226,7 +234,11 @@ extension TouchService: Service {
         }
 
         if settings.isApplePencilActive {
-            let pencilData: [[String: CGFloat]] = payloads.map { payload in
+            let pencilData: [[String: CGFloat]] = touchPoints.compactMap { touch in
+                guard let payload = touchPayload(for: touch) else {
+                    return nil
+                }
+
                 return [
                     "x": payload.point.x,
                     "y": payload.point.y,

--- a/ZIGSIMPlusTests/TouchServiceTests.swift
+++ b/ZIGSIMPlusTests/TouchServiceTests.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 1→10, Inc. All rights reserved.
 //
 
-import SwiftOSC
+import OSCKit
 import SwiftyJSON
 import XCTest
 @testable import ZIG_SIM_PRO
@@ -44,6 +44,10 @@ class UITouchMock: UITouch {
     override var majorRadius: CGFloat { return _radius }
 
     override var force: CGFloat { return _force }
+}
+
+class UITouchNilViewMock: UITouchMock {
+    override var view: UIView? { return nil }
 }
 
 class TouchServiceTests: XCTestCase {
@@ -236,6 +240,21 @@ class TouchServiceTests: XCTestCase {
         AppSettingModel.shared.isActiveByCommand[.touch] = true
         let log = TouchService.shared.toLog()
         XCTAssertEqual(log, [], "Empty log")
+    }
+
+    func test_toLog_skipsTouchWithoutView() {
+        AppSettingModel.shared.isActiveByCommand[.touch] = true
+        AppSettingModel.shared.isActiveByCommand[.applePencil] = false
+        TouchService.shared.enable()
+
+        TouchService.shared.setTouchArea(rect: CGRect(x: 0, y: 0, width: 100, height: 100))
+        TouchService.shared.addTouches([UITouchNilViewMock(12, 34, 0.1, 0.2)])
+
+        XCTAssertEqual(TouchService.shared.toLog(), [], "Touch without view is ignored")
+        XCTAssertEqual(TouchService.shared.toOSC(), [], "Touch without view is ignored in OSC")
+        XCTAssertEqual(try! TouchService.shared.toJSON(), JSON(["touch": []]), "Touch without view is ignored in JSON")
+
+        TouchService.shared.disable()
     }
 
     func test_toLog() {

--- a/ZIGSIMPlusTests/TouchServiceTests.swift
+++ b/ZIGSIMPlusTests/TouchServiceTests.swift
@@ -257,6 +257,27 @@ class TouchServiceTests: XCTestCase {
         TouchService.shared.disable()
     }
 
+    func test_toOSC_preservesOriginalIndexWhenEarlierTouchHasNoView() {
+        AppSettingModel.shared.isActiveByCommand[.touch] = true
+        AppSettingModel.shared.isActiveByCommand[.applePencil] = false
+        TouchService.shared.enable()
+
+        TouchService.shared.setTouchArea(rect: CGRect(x: 0, y: 0, width: 100, height: 100))
+        TouchService.shared.addTouches([
+            UITouchNilViewMock(12, 34, 0.1, 0.2),
+            UITouchMock(56, 78, 0.3, 0.4),
+        ])
+
+        let osc = TouchService.shared.toOSC()
+        XCTAssertEqual(osc.count, 4, "Only the valid touch emits OSC messages")
+        XCTAssert(osc[0].address.string.contains("/touch11"), "Valid touch keeps its original index")
+        XCTAssert(osc[1].address.string.contains("/touch12"), "Valid touch keeps its original index")
+        XCTAssert(osc[2].address.string.contains("/touchradius1"), "Valid touch keeps its original index")
+        XCTAssert(osc[3].address.string.contains("/touchforce1"), "Valid touch keeps its original index")
+
+        TouchService.shared.disable()
+    }
+
     func test_toLog() {
         AppSettingModel.shared.isActiveByCommand[.touch] = true
         TouchService.shared.enable()


### PR DESCRIPTION
# Summary

- Refactors `TouchService` to compute shared touch payload data once and reuse it across `toLog()`, `toOSC()`, and `toJSON()`.

---

# Related Issue

Closes #125

---

# Scope

## In Scope

- Extract shared touch settings and payload helpers inside `TouchService`
- Remove `touch.view!` force unwraps and obsolete iOS 8/9 availability branches
- Add a focused regression test for touches without an attached view

## Out of Scope (Non-goals)

- Changes to the `Service` protocol
- Broader `AppSettingModel` dependency cleanup
- Output format changes for OSC addresses or JSON keys

---

# Changes

- Added private `TouchCommandSettings` and `TouchPayload` helpers to centralize activation lookup, coordinate remapping, and per-touch data extraction
- Updated `toLog()`, `toOSC()`, and `toJSON()` to consume the shared payload path while preserving existing output formats
- Replaced the previous `fatalError` path with guarded early returns and added a unit test covering a touch whose `view` is `nil`

---

# Validation

## Commands Run

- `rg -n "touch\.view!|fatalError\(|#available\(iOS [89]" ZIGSIMPlus/Models/Services/TouchService.swift`
- `xcodebuild test -project ZIGSIMPlus.xcodeproj -scheme ZIGSIMPlusTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.3.1' -derivedDataPath /tmp/ZIGSIMPlusDerivedData -clonedSourcePackagesDirPath /tmp/ZIGSIMPlusSourcePackages -only-testing:ZIGSIMPlusTests/TouchServiceTests`

## Results

- Source check confirmed removal of `touch.view!`, `fatalError`, and iOS 8/9 availability branches from `TouchService.swift`
- `xcodebuild test` progressed through package resolution and compilation but failed at app link time on a pre-existing simulator linkage issue in `Private/Prototypes/NDISwift/ofxNDI/libs/NDI/lib/ios/libndi_ios.a`, so `TouchServiceTests` did not execute

---

# Device Testing

- Status: Pending (`needs-device-test`)
- Notes: Touch and Apple Pencil behavior should be verified on real hardware; Apple Pencil paths especially need iPad device coverage

---

# Risks / Concerns

- `toJSON()` still emits `pencil` payload entries whenever the Apple Pencil command is active, matching prior behavior even though that behavior may deserve separate review
- Full automated validation is currently blocked by the unrelated simulator linker failure against `libndi_ios.a`

---

# Additional Notes

- Diff is intentionally limited to `TouchService.swift` and `TouchServiceTests.swift` for Issue #125

# Checklist

- [x] Branch is created from `modernize`
- [x] PR targets `modernize`
- [x] Scope matches Issue
- [x] No unrelated changes included
- [x] Validation commands were executed
- [x] Risks are documented
- [x] Device testing requirement is stated