### PR TITLE
Remove dead iOS 15 navbar branches

### DIFF
--- a/ZIGSIMPlus/Utils.swift
+++ b/ZIGSIMPlus/Utils.swift
@@ -76,6 +76,16 @@ class Utils {
         topItem.titleView = wrapper
     }
 
+    static func configureNavigationBar(_ navBar: UINavigationBar) {
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = Theme.dark
+        navBar.standardAppearance = appearance
+        navBar.scrollEdgeAppearance = appearance
+        navBar.tintColor = Theme.main
+        setTitleImage(navBar)
+    }
+
     static func isValidBeaconUUID(_ uuid: String) -> Bool {
         // swiftlint:disable:next force_try
         let reg = try! NSRegularExpression(pattern: "[A-Z0-9]{8}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{12}")

--- a/ZIGSIMPlus/Views/CommandOutputViewController.swift
+++ b/ZIGSIMPlus/Views/CommandOutputViewController.swift
@@ -26,19 +26,7 @@ class CommandOutputViewController: UIViewController {
         super.viewDidLoad()
 
         // Initialize navigation bar
-        let navBar = navigationController!.navigationBar
-        if #available(iOS 15.0, *) {
-            let appearance = UINavigationBarAppearance()
-            appearance.configureWithOpaqueBackground()
-            appearance.backgroundColor = Theme.dark
-            navBar.standardAppearance = appearance
-            navBar.scrollEdgeAppearance = appearance
-            navBar.tintColor = Theme.main
-        } else {
-            navBar.barTintColor = Theme.dark
-            navBar.tintColor = Theme.main
-        }
-        Utils.setTitleImage(navBar)
+        Utils.configureNavigationBar(navigationController!.navigationBar)
 
         presenter.composeChildViewArchitecture()
     }

--- a/ZIGSIMPlus/Views/CommandSelectionViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSelectionViewController.swift
@@ -7,7 +7,6 @@
 //
 
 import MarkdownKit
-import SVProgressHUD
 import UIKit
 
 typealias CommandToSelect = (labelString: String, isAvailable: Bool)
@@ -96,18 +95,7 @@ final class CommandSelectionViewController: UIViewController {
     }
 
     private func adjustNavigationDesign() {
-        Utils.setTitleImage(navigationController!.navigationBar)
-        if #available(iOS 15.0, *) {
-            let appearance = UINavigationBarAppearance()
-            appearance.configureWithOpaqueBackground()
-            appearance.backgroundColor = Theme.dark
-            navigationController?.navigationBar.standardAppearance = appearance
-            navigationController?.navigationBar.scrollEdgeAppearance = appearance
-            navigationController?.navigationBar.tintColor = Theme.main
-        } else {
-            navigationController?.navigationBar.barTintColor = Theme.dark
-            navigationController?.navigationBar.tintColor = Theme.main
-        }
+        Utils.configureNavigationBar(navigationController!.navigationBar)
     }
 
     private func convertMessageFromStringToAttributedText(_ msg: String) -> NSMutableAttributedString {

--- a/ZIGSIMPlus/Views/CommandSettingViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSettingViewController.swift
@@ -127,18 +127,7 @@ public class CommandSettingViewController: UIViewController {
     }
 
     private func initNavigationBar() {
-        Utils.setTitleImage(navigationController!.navigationBar)
-        if #available(iOS 15.0, *) {
-            let appearance = UINavigationBarAppearance()
-            appearance.configureWithOpaqueBackground()
-            appearance.backgroundColor = Theme.dark
-            navigationController?.navigationBar.standardAppearance = appearance
-            navigationController?.navigationBar.scrollEdgeAppearance = appearance
-            navigationController?.navigationBar.tintColor = Theme.main
-        } else {
-            navigationController?.navigationBar.barTintColor = Theme.dark
-            navigationController?.navigationBar.tintColor = Theme.main
-        }
+        Utils.configureNavigationBar(navigationController!.navigationBar)
     }
 }
 


### PR DESCRIPTION
# Summary

- Removes the dead `if #available(iOS 15.0, *) { ... } else { ... }` navbar branches from the three command screens and centralizes the shared iOS 15 navbar setup.

---

# Related Issue

Closes #122

---

# Scope

## In Scope

- Remove the unreachable iOS 15 navbar `else` branches from the three specified view controllers
- Extract the shared navbar appearance setup into a common helper alongside `Utils.setTitleImage(_:)`
- Keep the existing dark background, tint color, and title image behavior aligned across the three screens

## Out of Scope (Non-goals)

- Visual design changes to the navigation bar
- Storyboard or XIB updates
- Broader cleanup of unrelated availability checks outside these three screens

---

# Changes

- Added `Utils.configureNavigationBar(_:)` to apply the existing iOS 15 navbar appearance and title image in one place
- Replaced duplicated navbar setup in `CommandSelectionViewController`, `CommandSettingViewController`, and `CommandOutputViewController` with the shared helper
- Removed the dead `barTintColor` fallback branches now that the minimum OS is iOS 15

---

# Validation

## Commands Run

- `rg -n "#available\(iOS 15\.0, \*\)|barTintColor|configureNavigationBar\(" ZIGSIMPlus/Views/CommandSelectionViewController.swift ZIGSIMPlus/Views/CommandSettingViewController.swift ZIGSIMPlus/Views/CommandOutputViewController.swift ZIGSIMPlus/Utils.swift`
- `xcodebuild test -project ZIGSIMPlus.xcodeproj -scheme ZIGSIMPlusTests -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.3.1' -derivedDataPath /tmp/ZIGSIMPlusDerivedData -clonedSourcePackagesDirPath /tmp/ZIGSIMPlusSourcePackages -only-testing:ZIGSIMPlusTests/TouchServiceTests`

## Results

- Source check confirms the three view controllers now call the shared helper, and the iOS 15 `#available` / `barTintColor` branches are removed
- The Xcode run reached app linking and failed on the existing unrelated simulator linker issue in `Private/Prototypes/NDISwift/ofxNDI/libs/NDI/lib/ios/libndi_ios.a`, so full simulator validation is still blocked by current branch state

---

# Device Testing

- Status: Not required
- Notes: This issue is limited to removal of dead iOS 15 branches and shared setup extraction; simulator visual confirmation is still useful when the existing linker blocker is resolved

---

# Risks / Concerns

- I could not complete simulator visual verification in this environment because the current branch still fails at an unrelated NDI simulator link step
- The shared helper now owns both appearance setup and title image application, so any future navbar-specific customization on one screen would need an explicit override

---

# Additional Notes

- Diff is intentionally limited to `Utils.swift` and the three command screen view controllers listed in the issue

# Checklist

- [x] Branch is created from `modernize`
- [x] PR targets `modernize`
- [x] Scope matches Issue
- [x] No unrelated changes included
- [x] Validation commands were executed
- [x] Risks are documented
- [x] Device testing requirement is stated