### PR TITLE
Issue #123: make CommandSelectionViewController unwraps safe

### DIFF
--- a/ZIGSIMPlus/Views/CommandSelectionViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSelectionViewController.swift
@@ -86,7 +86,11 @@ final class CommandSelectionViewController: UIViewController {
         let attributedText = convertMessageFromStringToAttributedText(message)
         alert.setValue(attributedText, forKey: "attributedMessage")
         alert.addAction(UIAlertAction(title: "See Docs", style: .default, handler: { _ in
-            UIApplication.shared.open(URL(string: "https://1-10.github.io/zigsim/")!, options: [:])
+            guard let url = URL(string: "https://1-10.github.io/zigsim/") else {
+                assertionFailure("Failed to create docs URL")
+                return
+            }
+            UIApplication.shared.open(url, options: [:])
         }))
         alert.addAction(UIAlertAction(title: "OK", style: .default))
         present(alert, animated: true, completion: {
@@ -95,7 +99,11 @@ final class CommandSelectionViewController: UIViewController {
     }
 
     private func adjustNavigationDesign() {
-        Utils.configureNavigationBar(navigationController!.navigationBar)
+        guard let navigationController else {
+            assertionFailure("CommandSelectionViewController must be embedded in a navigation controller")
+            return
+        }
+        Utils.configureNavigationBar(navigationController.navigationBar)
     }
 
     private func convertMessageFromStringToAttributedText(_ msg: String) -> NSMutableAttributedString {
@@ -108,7 +116,10 @@ extension CommandSelectionViewController: UITableViewDelegate {
     // Disallow selecting unavailable command
     func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
         if let cell = tableView.cellForRow(at: indexPath) {
-            let ipForCell = tableView.indexPath(for: cell)!
+            guard let ipForCell = tableView.indexPath(for: cell) else {
+                assertionFailure("Failed to resolve indexPath for selected cell")
+                return indexPath
+            }
             let commandToSelect = presenter.getCommandToSelect(forRow: ipForCell.row)
             if !commandToSelect.isAvailable {
                 return nil
@@ -138,7 +149,7 @@ extension CommandSelectionViewController: UITableViewDataSource {
         cell.commandSelectionPresenter = presenter
         cells[Command.allCases[indexPath.row]] = cell
 
-        if AppSettingModel.shared.isActiveByCommand[Command.allCases[indexPath.row]]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.allCases[indexPath.row]] ?? false {
             cell.checkMarkLavel.text = checkMark
         } else {
             cell.checkMarkLavel.text = ""

--- a/ZIGSIMPlus/Views/CommandSettingViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSettingViewController.swift
@@ -127,8 +127,7 @@ public class CommandSettingViewController: UIViewController {
     }
 
     private func initNavigationBar() {
-        guard let navigationController else { return }
-        Utils.configureNavigationBar(navigationController.navigationBar)
+        Utils.configureNavigationBar(navigationController!.navigationBar)
     }
 }
 
@@ -171,19 +170,14 @@ extension CommandSettingViewController: ContentScrollable {
 
     func removeObserver() {
         NotificationCenter.default.removeObserver(self)
-        if let showObserver {
-            NotificationCenter.default.removeObserver(showObserver)
-        }
-        if let hideObserver {
-            NotificationCenter.default.removeObserver(hideObserver)
-        }
+        if showObserver != nil { NotificationCenter.default.removeObserver(showObserver! as Any) }
+        if hideObserver != nil { NotificationCenter.default.removeObserver(hideObserver! as Any) }
     }
 
     func keyboardWillShow(_ notification: Notification) {
         guard let userInfo = notification.userInfo else { return }
-        guard let keyboardSize = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue.height else {
-            return
-        }
+        // swiftlint:disable:next force_cast
+        let keyboardSize = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as! NSValue).cgRectValue.height
         scrollView.contentInset.bottom = keyboardSize
     }
 

--- a/ZIGSIMPlus/Views/CommandSettingViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSettingViewController.swift
@@ -127,7 +127,8 @@ public class CommandSettingViewController: UIViewController {
     }
 
     private func initNavigationBar() {
-        Utils.configureNavigationBar(navigationController!.navigationBar)
+        guard let navigationController else { return }
+        Utils.configureNavigationBar(navigationController.navigationBar)
     }
 }
 
@@ -170,14 +171,19 @@ extension CommandSettingViewController: ContentScrollable {
 
     func removeObserver() {
         NotificationCenter.default.removeObserver(self)
-        if showObserver != nil { NotificationCenter.default.removeObserver(showObserver! as Any) }
-        if hideObserver != nil { NotificationCenter.default.removeObserver(hideObserver! as Any) }
+        if let showObserver {
+            NotificationCenter.default.removeObserver(showObserver)
+        }
+        if let hideObserver {
+            NotificationCenter.default.removeObserver(hideObserver)
+        }
     }
 
     func keyboardWillShow(_ notification: Notification) {
         guard let userInfo = notification.userInfo else { return }
-        // swiftlint:disable:next force_cast
-        let keyboardSize = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as! NSValue).cgRectValue.height
+        guard let keyboardSize = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue.height else {
+            return
+        }
         scrollView.contentInset.bottom = keyboardSize
     }
 


### PR DESCRIPTION
# Summary

- Replace force unwraps in `CommandSelectionViewController` with safe unwrapping and fallback behavior.

---

# Related Issue

Closes #123

---

# Scope

## In Scope

- Safe handling for the docs URL creation in `showAlertWithMarkdownMessage`
- Safe handling for `navigationController` in `adjustNavigationDesign`
- Safe handling for `tableView.indexPath(for:)` in row selection
- Safe fallback for `isActiveByCommand` dictionary lookups in cell rendering

## Out of Scope (Non-goals)

- Any `AppSettingModel` design changes
- Navigation controller injection changes
- Force unwrap cleanup in files other than `CommandSelectionViewController.swift`

---

# Changes

- Replaced `URL(string: ...)!` with `guard let` and an early return plus `assertionFailure`
- Replaced `navigationController!` with `guard let` and an early return plus `assertionFailure`
- Replaced `tableView.indexPath(for: cell)!` with guarded lookup and a fallback return of the original `indexPath`
- Replaced `isActiveByCommand[...]!` with `?? false` to avoid crashes on missing keys

---

# Validation

## Commands Run

- `xcodebuild -list -project ZIGSIMPlus.xcodeproj`
- `xcodebuild build -project ZIGSIMPlus.xcodeproj -scheme ZIGSIMPlus -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO`

## Results

- `xcodebuild -list` succeeded and confirmed the shared `ZIGSIMPlus` scheme
- `xcodebuild build` failed during app linking because `/Private/Prototypes/NDISwift/ofxNDI/libs/NDI/lib/ios/libndi_ios.a` is built for iOS and cannot be linked into an iOS Simulator build
- No build error was reported from the `CommandSelectionViewController.swift` change itself before the unrelated linker failure
- Simulator UI validation for the command selection screen was not completed because the app did not finish linking for the simulator

---

# Device Testing

- Status: Pending (`needs-device-test`)
- Notes: Repo policy requires explicit device validation. The issue requested simulator confirmation, but simulator validation is currently blocked by the unrelated linker failure above.

---

# Risks / Concerns

- `adjustNavigationDesign()` now fails safely instead of crashing if the view controller is presented without a navigation controller; in that misconfigured case the navigation bar style will simply not be applied
- Missing `isActiveByCommand` entries now render as unchecked instead of crashing, which is safer but may hide upstream data inconsistencies
- Simulator verification remains blocked by the existing NDI linker issue

---

# Additional Notes

- This PR is intentionally limited to `ZIGSIMPlus/Views/CommandSelectionViewController.swift`
- The branch diff was cleaned to avoid including unrelated changes from another issue

# Checklist

- [x] Branch is created from `modernize`
- [x] PR targets `modernize`
- [x] Scope matches Issue
- [x] No unrelated changes included
- [x] Validation commands were executed
- [x] Risks are documented
- [x] Device testing requirement is stated
