### PR TITLE
Issue #124: Replace unsafe unwraps in CommandSettingViewController

### DIFF
--- a/ZIGSIMPlus/Views/CommandSettingViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSettingViewController.swift
@@ -127,7 +127,8 @@ public class CommandSettingViewController: UIViewController {
     }
 
     private func initNavigationBar() {
-        Utils.configureNavigationBar(navigationController!.navigationBar)
+        guard let navigationController else { return }
+        Utils.configureNavigationBar(navigationController.navigationBar)
     }
 }
 
@@ -170,14 +171,19 @@ extension CommandSettingViewController: ContentScrollable {
 
     func removeObserver() {
         NotificationCenter.default.removeObserver(self)
-        if showObserver != nil { NotificationCenter.default.removeObserver(showObserver! as Any) }
-        if hideObserver != nil { NotificationCenter.default.removeObserver(hideObserver! as Any) }
+        if let showObserver {
+            NotificationCenter.default.removeObserver(showObserver)
+        }
+        if let hideObserver {
+            NotificationCenter.default.removeObserver(hideObserver)
+        }
     }
 
     func keyboardWillShow(_ notification: Notification) {
         guard let userInfo = notification.userInfo else { return }
-        // swiftlint:disable:next force_cast
-        let keyboardSize = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as! NSValue).cgRectValue.height
+        guard let keyboardSize = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue.height else {
+            return
+        }
         scrollView.contentInset.bottom = keyboardSize
     }
 


### PR DESCRIPTION
# Summary

- Replaced the unsafe unwrap and cast sites in `CommandSettingViewController` with safe optional handling to remove the documented crash paths.

---

# Related Issue

Closes #124

---

# Scope

## In Scope

- Guard `navigationController` before accessing `navigationBar`
- Replace forced observer unwraps with `if let` removal
- Replace the forced keyboard frame cast with an optional cast guarded early return

## Out of Scope (Non-goals)

- No redesign of `addObserver` / `removeObserver`
- No Combine migration for `NotificationCenter`
- No broader navigation bar initialization changes beyond removing the force unwrap

---

# Changes

- Updated `initNavigationBar()` to return early when `navigationController` is unavailable
- Updated `removeObserver()` to remove `showObserver` and `hideObserver` without force unwrapping
- Updated `keyboardWillShow(_:)` to safely read `UIResponder.keyboardFrameEndUserInfoKey` as `NSValue`

---

# Validation

## Commands Run

- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO -derivedDataPath /tmp/ZIGSIMPlus_issue124_dd build`

## Results

- The branch diff is limited to `ZIGSIMPlus/Views/CommandSettingViewController.swift`
- The `xcodebuild` command did not complete in this environment
- Observed errors included `CoreSimulatorService connection became invalid` and `xcodebuild: error: 'ZIGSIMPlus.xcworkspace' is not a workspace file.`
- Simulator keyboard interaction was not validated in this environment

---

# Device Testing

- Status: Not required
- Notes: Real-device testing is not required for this issue. Simulator validation is still required to confirm keyboard display and scroll-view inset tracking.

---

# Risks / Concerns

- `initNavigationBar()` now exits early when the controller is not embedded in a navigation controller, which removes the crash but leaves the existing embedding assumption unchanged
- `keyboardWillShow(_:)` now ignores malformed notification payloads instead of crashing
- Build and simulator validation remain pending because the local environment could not complete the workspace build

---

# Additional Notes

- Branch `future/issue-124-fix-force-unwrap-command-setting` is based on `modernize`
- PR target is `modernize`

# Checklist

- [x] Branch is created from `modernize`
- [x] PR targets `modernize`
- [x] Scope matches Issue
- [x] No unrelated changes included
- [x] Validation commands were executed
- [x] Risks are documented
- [x] Device testing requirement is stated
