### PR TITLE
Fix force unwraps in AppSettingModel

### DIFF
--- a/ZIGSIMPlus/Models/AppSettingModel.swift
+++ b/ZIGSIMPlus/Models/AppSettingModel.swift
@@ -152,21 +152,21 @@ public class AppSettingModel {
     public func isCameraUsed(exceptBy command: Command? = nil) -> Bool {
         var isCameraUsed = false
         if command != .arkit {
-            isCameraUsed = (isCameraUsed || isActiveByCommand[.arkit]!)
+            isCameraUsed = (isCameraUsed || (isActiveByCommand[.arkit] ?? false))
         }
         if command != .ndi {
-            isCameraUsed = (isCameraUsed || isActiveByCommand[.ndi]!)
+            isCameraUsed = (isCameraUsed || (isActiveByCommand[.ndi] ?? false))
         }
         if command != .imageDetection {
-            isCameraUsed = (isCameraUsed || isActiveByCommand[.imageDetection]!)
+            isCameraUsed = (isCameraUsed || (isActiveByCommand[.imageDetection] ?? false))
         }
 
         return isCameraUsed
     }
 
     public func isTouchEnabled() -> Bool {
-        return AppSettingModel.shared.isActiveByCommand[.touch]! ||
-            AppSettingModel.shared.isActiveByCommand[.applePencil]!
+        return (AppSettingModel.shared.isActiveByCommand[.touch] ?? false) ||
+            (AppSettingModel.shared.isActiveByCommand[.applePencil] ?? false)
     }
 }
 


### PR DESCRIPTION
Linked Issue
Closes #134

Summary
Replace the five `isActiveByCommand[...]!` force unwraps in `AppSettingModel.isCameraUsed()` and `AppSettingModel.isTouchEnabled()` with `?? false` fallbacks.

Scope
Update only `AppSettingModel.swift` in the two methods named in the issue.

Non-goals
Do not change the `isActiveByCommand` dictionary design.
Do not touch service files that still use force unwraps.
Do not change any other `AppSettingModel` methods.

Changes
- Replaced three force unwraps in `isCameraUsed()` with `?? false`.
- Replaced two force unwraps in `isTouchEnabled()` with `?? false`.

Validation steps
- `rg -n "isActiveByCommand\\[\\.(arkit|ndi|imageDetection|touch|applePencil)\\]" ZIGSIMPlus/Models/AppSettingModel.swift`
- `xcodebuild -project ZIGSIMPlus.xcodeproj -scheme ZIGSIMPlus -configuration Debug -destination 'generic/platform=iOS Simulator' build`

Results
- `rg` confirmed the five targeted accesses now use `?? false`.
- `xcodebuild` failed before compilation completed because the project references missing CocoaPods-generated files such as `Pods/Target Support Files/Pods-ZIGSIMPlus/Pods-ZIGSIMPlus.debug.xcconfig` and related `xcfilelist` files.

Risks
- Behavior changes only when a command key is missing from `isActiveByCommand`; those paths now return `false` instead of crashing.
- Full build validation remains blocked by the repository's current missing Pods configuration references.

Device test requirements
- Simulator verification of the command output screen was not run from this environment.
- Real-device validation remains required by repository policy.
- needs-device-test
