### PR TITLE
Issue #135: replace service force unwraps with nil-coalescing

### DIFF
--- a/ZIGSIMPlus/Models/Services/AltimeterService.swift
+++ b/ZIGSIMPlus/Models/Services/AltimeterService.swift
@@ -82,7 +82,7 @@ extension AltimeterService: Service {
     func toLog() -> [String] {
         var log = [String]()
 
-        if AppSettingModel.shared.isActiveByCommand[Command.pressure]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.pressure] ?? false {
             log += [
                 "pressure:pressure:\(pressureData)",
                 "pressure:altitude:\(altitudeData)",
@@ -95,7 +95,7 @@ extension AltimeterService: Service {
     func toOSC() -> [OSCMessage] {
         var messages = [OSCMessage]()
 
-        if AppSettingModel.shared.isActiveByCommand[Command.pressure]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.pressure] ?? false {
             messages.append(osc("pressure", pressureData, altitudeData))
         }
 
@@ -105,7 +105,7 @@ extension AltimeterService: Service {
     func toJSON() -> JSON {
         var data = JSON()
 
-        if AppSettingModel.shared.isActiveByCommand[Command.pressure]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.pressure] ?? false {
             data["pressure"] = [
                 "pressure": pressureData,
                 "altitude": altitudeData,

--- a/ZIGSIMPlus/Models/Services/AudioLevelService.swift
+++ b/ZIGSIMPlus/Models/Services/AudioLevelService.swift
@@ -134,7 +134,7 @@ extension AudioLevelService: Service {
     func toLog() -> [String] {
         var log = [String]()
 
-        if AppSettingModel.shared.isActiveByCommand[Command.micLevel]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.micLevel] ?? false {
             log += [
                 "miclevel:max\(maxLevel)",
                 "miclevel:average\(averageLevel)",
@@ -147,7 +147,7 @@ extension AudioLevelService: Service {
     func toOSC() -> [OSCMessage] {
         var data = [OSCMessage]()
 
-        if AppSettingModel.shared.isActiveByCommand[Command.micLevel]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.micLevel] ?? false {
             data.append(osc("miclevel", maxLevel, averageLevel))
         }
 
@@ -157,7 +157,7 @@ extension AudioLevelService: Service {
     func toJSON() -> JSON {
         var data = JSON()
 
-        if AppSettingModel.shared.isActiveByCommand[Command.micLevel]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.micLevel] ?? false {
             data["miclevel"] = [
                 "average": averageLevel,
                 "max": maxLevel,

--- a/ZIGSIMPlus/Models/Services/BatteryService.swift
+++ b/ZIGSIMPlus/Models/Services/BatteryService.swift
@@ -47,7 +47,7 @@ extension BatteryService: Service {
     func toLog() -> [String] {
         var log = [String]()
 
-        if AppSettingModel.shared.isActiveByCommand[Command.battery]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.battery] ?? false {
             if isBatteryError {
                 log.append("battery level unknown")
             } else {
@@ -61,7 +61,7 @@ extension BatteryService: Service {
     func toOSC() -> [OSCMessage] {
         var messages = [OSCMessage]()
 
-        if AppSettingModel.shared.isActiveByCommand[Command.battery]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.battery] ?? false {
             messages.append(osc("battery", battery))
         }
 
@@ -71,7 +71,7 @@ extension BatteryService: Service {
     func toJSON() throws -> JSON {
         var data = JSON()
 
-        if AppSettingModel.shared.isActiveByCommand[Command.battery]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.battery] ?? false {
             data["battery"] = JSON(battery)
         }
 

--- a/ZIGSIMPlus/Models/Services/LocationService.swift
+++ b/ZIGSIMPlus/Models/Services/LocationService.swift
@@ -169,21 +169,21 @@ extension LocationService: Service {
     func toLog() -> [String] {
         var log = [String]()
 
-        if AppSettingModel.shared.isActiveByCommand[Command.gps]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.gps] ?? false {
             log += [
                 "gps:latitude:\(latitudeData)",
                 "gps:longitude:\(longitudeData)",
             ]
         }
 
-        if AppSettingModel.shared.isActiveByCommand[Command.compass]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.compass] ?? false {
             log += [
                 "compass:compass:\(compassData)",
                 "compass:orientation:\(AppSettingModel.shared.compassOrientation == .faceup ? "faceup" : "portrait")",
             ]
         }
 
-        if AppSettingModel.shared.isActiveByCommand[Command.beacon]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.beacon] ?? false {
             log += beacons.enumerated().map { i, b in // swiftlint:disable:this identifier_name
                 let uuid = b.proximityUUID.uuidString
                 let major = b.major.intValue
@@ -198,15 +198,15 @@ extension LocationService: Service {
     func toOSC() -> [OSCMessage] {
         var data = [OSCMessage]()
 
-        if AppSettingModel.shared.isActiveByCommand[Command.gps]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.gps] ?? false {
             data.append(osc("gps", latitudeData, longitudeData))
         }
 
-        if AppSettingModel.shared.isActiveByCommand[Command.compass]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.compass] ?? false {
             data.append(osc("compass", compassData, AppSettingModel.shared.compassOrientation.rawValue))
         }
 
-        if AppSettingModel.shared.isActiveByCommand[Command.beacon]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.beacon] ?? false {
             data += beacons.enumerated().map { i, beacon in
                 osc(
                     "beacon\(i)",
@@ -224,18 +224,18 @@ extension LocationService: Service {
     func toJSON() -> JSON {
         var data = JSON()
 
-        if AppSettingModel.shared.isActiveByCommand[Command.gps]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.gps] ?? false {
             data["gps"] = JSON(["latitude": latitudeData, "longitude": longitudeData])
         }
 
-        if AppSettingModel.shared.isActiveByCommand[Command.compass]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.compass] ?? false {
             data["compass"] = JSON([
                 "compass": compassData,
                 "faceup": AppSettingModel.shared.compassOrientation.rawValue,
             ])
         }
 
-        if AppSettingModel.shared.isActiveByCommand[Command.beacon]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.beacon] ?? false {
             let objs = beacons.map { beacon in
                 [
                     "uuid": beacon.proximityUUID.uuidString,

--- a/ZIGSIMPlus/Models/Services/MotionService.swift
+++ b/ZIGSIMPlus/Models/Services/MotionService.swift
@@ -72,7 +72,7 @@ extension MotionService: Service {
             ]
         }
 
-        if AppSettingModel.shared.isActiveByCommand[Command.acceleration]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.acceleration] ?? false {
             log += [
                 "accel:x:\(accel.x)",
                 "accel:y:\(accel.y)",
@@ -80,7 +80,7 @@ extension MotionService: Service {
             ]
         }
 
-        if AppSettingModel.shared.isActiveByCommand[Command.gravity]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.gravity] ?? false {
             log += [
                 "gravity:x:\(gravity.x)",
                 "gravity:y:\(gravity.y)",
@@ -88,7 +88,7 @@ extension MotionService: Service {
             ]
         }
 
-        if AppSettingModel.shared.isActiveByCommand[Command.gyro]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.gyro] ?? false {
             log += [
                 "gyro:x:\(gyro.x)",
                 "gyro:y:\(gyro.y)",
@@ -96,7 +96,7 @@ extension MotionService: Service {
             ]
         }
 
-        if AppSettingModel.shared.isActiveByCommand[Command.quaternion]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.quaternion] ?? false {
             log += [
                 "quaternion:x:\(quaternion.x)",
                 "quaternion:y:\(quaternion.y)",
@@ -111,19 +111,19 @@ extension MotionService: Service {
     func toOSC() -> [OSCMessage] {
         var messages = [OSCMessage]()
 
-        if AppSettingModel.shared.isActiveByCommand[Command.acceleration]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.acceleration] ?? false {
             messages.append(osc("accel", accel.x, accel.y, accel.z))
         }
 
-        if AppSettingModel.shared.isActiveByCommand[Command.gravity]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.gravity] ?? false {
             messages.append(osc("gravity", gravity.x, gravity.y, gravity.z))
         }
 
-        if AppSettingModel.shared.isActiveByCommand[Command.gyro]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.gyro] ?? false {
             messages.append(osc("gyro", gyro.x, gyro.y, gyro.z))
         }
 
-        if AppSettingModel.shared.isActiveByCommand[Command.quaternion]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.quaternion] ?? false {
             messages.append(osc("quaternion", quaternion.x, quaternion.y, quaternion.z, quaternion.w))
         }
 
@@ -133,7 +133,7 @@ extension MotionService: Service {
     func toJSON() throws -> JSON {
         var data = JSON()
 
-        if AppSettingModel.shared.isActiveByCommand[Command.acceleration]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.acceleration] ?? false {
             data["accel"] = [
                 "x": accel.x,
                 "y": accel.y,
@@ -141,7 +141,7 @@ extension MotionService: Service {
             ]
         }
 
-        if AppSettingModel.shared.isActiveByCommand[Command.gravity]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.gravity] ?? false {
             data["gravity"] = [
                 "x": gravity.x,
                 "y": gravity.y,
@@ -149,7 +149,7 @@ extension MotionService: Service {
             ]
         }
 
-        if AppSettingModel.shared.isActiveByCommand[Command.gyro]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.gyro] ?? false {
             data["gyro"] = [
                 "x": gyro.x,
                 "y": gyro.y,
@@ -157,7 +157,7 @@ extension MotionService: Service {
             ]
         }
 
-        if AppSettingModel.shared.isActiveByCommand[Command.quaternion]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.quaternion] ?? false {
             data["quaternion"] = [
                 "x": quaternion.x,
                 "y": quaternion.y,

--- a/ZIGSIMPlus/Models/Services/ProximityService.swift
+++ b/ZIGSIMPlus/Models/Services/ProximityService.swift
@@ -50,7 +50,7 @@ extension ProximityService: Service {
     func toLog() -> [String] {
         var log = [String]()
 
-        if AppSettingModel.shared.isActiveByCommand[Command.proximity]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.proximity] ?? false {
             log += [
                 "proximitymonitor:proximitymonitor:\(proximity)",
             ]
@@ -62,7 +62,7 @@ extension ProximityService: Service {
     func toOSC() -> [OSCMessage] {
         var data = [OSCMessage]()
 
-        if AppSettingModel.shared.isActiveByCommand[Command.proximity]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.proximity] ?? false {
             data.append(osc("proximitymonitor", proximity ? 1 : 0))
         }
 
@@ -72,7 +72,7 @@ extension ProximityService: Service {
     func toJSON() throws -> JSON {
         var data = JSON()
 
-        if AppSettingModel.shared.isActiveByCommand[Command.proximity]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.proximity] ?? false {
             data["proximitymonitor"] = JSON(["proximitymonitor": proximity])
         }
 

--- a/ZIGSIMPlus/Models/Services/RemoteControlService.swift
+++ b/ZIGSIMPlus/Models/Services/RemoteControlService.swift
@@ -117,7 +117,7 @@ extension RemoteControlService: Service {
     func toLog() -> [String] {
         var log = [String]()
 
-        if AppSettingModel.shared.isActiveByCommand[Command.remoteControl]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.remoteControl] ?? false {
             log += [
                 "remotecontrol:playpause \(playPauseChanged)",
                 "remotecontrol:volumeup \(volumeUp)",
@@ -133,7 +133,7 @@ extension RemoteControlService: Service {
     func toOSC() -> [OSCMessage] {
         var messages = [OSCMessage]()
 
-        if AppSettingModel.shared.isActiveByCommand[Command.remoteControl]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.remoteControl] ?? false {
             messages.append(osc(
                 "remotecontrol",
                 playPauseChanged,
@@ -150,7 +150,7 @@ extension RemoteControlService: Service {
     func toJSON() throws -> JSON {
         var data = JSON()
 
-        if AppSettingModel.shared.isActiveByCommand[Command.remoteControl]! {
+        if AppSettingModel.shared.isActiveByCommand[Command.remoteControl] ?? false {
             data["remotecontrol"] = JSON([
                 "playpause": playPauseChanged,
                 "volumeup": volumeUp,


### PR DESCRIPTION
## Linked Issue
- #135

## Summary
- Replaced `AppSettingModel.shared.isActiveByCommand[Command.xxx]!` with `AppSettingModel.shared.isActiveByCommand[Command.xxx] ?? false` in the seven in-scope service files.
- This removes dictionary force unwrap crash risk when a command key is missing.

## Scope
- `ZIGSIMPlus/Models/Services/LocationService.swift`
- `ZIGSIMPlus/Models/Services/BatteryService.swift`
- `ZIGSIMPlus/Models/Services/AudioLevelService.swift`
- `ZIGSIMPlus/Models/Services/MotionService.swift`
- `ZIGSIMPlus/Models/Services/ProximityService.swift`
- `ZIGSIMPlus/Models/Services/RemoteControlService.swift`
- `ZIGSIMPlus/Models/Services/AltimeterService.swift`

## Non-goals
- No changes to `AppSettingModel.swift`
- No design change to `isActiveByCommand`
- No service logic refactor beyond the nil-coalescing replacement

## Changes
- Replaced all in-scope `isActiveByCommand[...]!` checks with `isActiveByCommand[...] ?? false`
- Kept unrelated pre-existing local changes out of the commit

## Validation Commands
- `rg -n "isActiveByCommand\[.*\]!" ZIGSIMPlus/Models/Services/LocationService.swift ZIGSIMPlus/Models/Services/BatteryService.swift ZIGSIMPlus/Models/Services/AudioLevelService.swift ZIGSIMPlus/Models/Services/MotionService.swift ZIGSIMPlus/Models/Services/ProximityService.swift ZIGSIMPlus/Models/Services/RemoteControlService.swift ZIGSIMPlus/Models/Services/AltimeterService.swift`
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/ZIGSIMPlus-issue135-derived CODE_SIGNING_ALLOWED=NO build`

## Results
- `rg` returned no matches for the force-unwrap pattern in the seven target files.
- `xcodebuild` did not complete successfully. It failed at link time with an existing simulator linkage issue:
  - `ld: building for 'iOS-simulator', but linking in object file .../Private/Prototypes/NDISwift/ofxNDI/libs/NDI/lib/ios/libndi_ios.a ... built for 'iOS'`
- The build failure appears unrelated to this issue's nil-coalescing changes.

## Risks
- Medium: these checks gate command activation paths, so any unexpected reliance on missing dictionary keys now resolves to `false` instead of crashing.
- Full runtime verification of motion/GPS/battery/remote-control send paths was not completed in this task.

## Device Testing Requirement
- `needs-device-test`
- Repo policy requires real-device validation for service/data-send behavior. Simulator-only acceptance was not completed here.
