### PR TITLE
Fix CommandOutputPresenter retain cycle

### DIFF
--- a/ZIGSIMPlus/Presenters/CommandOutputPresenter.swift
+++ b/ZIGSIMPlus/Presenters/CommandOutputPresenter.swift
@@ -28,7 +28,8 @@ final class CommandOutputPresenter: CommandOutputPresenterProtocol {
     init(view: CommandOutputPresenterDelegate) {
         self.view = view
 
-        CommandPlayer.shared.onUpdate = {
+        CommandPlayer.shared.onUpdate = { [weak self] in
+            guard let self else { return }
             self.updateOutput()
         }
     }


### PR DESCRIPTION
Linked Issue
- Closes #136

Summary
- Add a weak capture to `CommandPlayer.shared.onUpdate` in `CommandOutputPresenter` so the presenter can deallocate when the screen is dismissed.

Scope
- Update the `onUpdate` closure in `CommandOutputPresenter.init()` to use `[weak self]` and `guard let self else { return }`.

Non-goals
- No changes to `CommandPlayer.onUpdate` design
- No presenter lifecycle redesign
- No unrelated refactors

Changes
- Replaced the strong `self` capture in `ZIGSIMPlus/Presenters/CommandOutputPresenter.swift` with a weak capture and early return before `updateOutput()`.

Validation commands
- `xcodebuild -list -project ZIGSIMPlus.xcodeproj`
- `xcodebuild -project ZIGSIMPlus.xcodeproj -scheme ZIGSIMPlus -configuration Debug -destination 'generic/platform=iOS' -derivedDataPath /tmp/ZIGSIMPlus_issue136_DerivedData CODE_SIGNING_ALLOWED=NO build`\n\nResults\n- `xcodebuild -list -project ZIGSIMPlus.xcodeproj`: passed\n- `xcodebuild ... build`: failed before compiling this change because the checkout is missing `Pods/Target Support Files/Pods-ZIGSIMPlus/Pods-ZIGSIMPlus.debug.xcconfig` and related Pods xcfilelists referenced by the project\n\nRisks\n- Low risk. The change only alters closure capture semantics for the singleton callback.\n- Full project build validation remains blocked in this environment until the missing Pods support files are available.\n\nDevice test requirements\n- not required