### PR TITLE
Issue #133: Move network sends off the main thread

### DIFF
--- a/ZIGSIMPlus/Models/CommandPlayer.swift
+++ b/ZIGSIMPlus/Models/CommandPlayer.swift
@@ -19,6 +19,7 @@ public class CommandPlayer {
     private init() {}
 
     private var updatingTimer: Timer?
+    private let networkQueue = DispatchQueue(label: "com.zigsim.commandPlayer.network")
     public var onUpdate: (() -> Void)?
     private var state: CommandPlayerState = .stopped
 
@@ -74,8 +75,7 @@ public class CommandPlayer {
             FileWriter.shared.open()
             FileWriter.shared.write(data)
         } else {
-            let data = ServiceManager.shared.getData()
-            NetworkAdapter.shared.send(data)
+            enqueueNetworkSend()
         }
 
         onUpdate?()
@@ -93,8 +93,7 @@ public class CommandPlayer {
             let data = ServiceManager.shared.getString()
             FileWriter.shared.write(data)
         } else {
-            let data = ServiceManager.shared.getData()
-            NetworkAdapter.shared.send(data)
+            enqueueNetworkSend()
         }
 
         onUpdate?()
@@ -121,5 +120,12 @@ public class CommandPlayer {
             fatalError("AppSetting for Command \"\(command)\" is nil")
         }
         return res
+    }
+
+    private func enqueueNetworkSend() {
+        let data = ServiceManager.shared.getData()
+        networkQueue.async {
+            NetworkAdapter.shared.send(data)
+        }
     }
 }

--- a/ZIGSIMPlus/Models/NetworkAdapter.swift
+++ b/ZIGSIMPlus/Models/NetworkAdapter.swift
@@ -15,6 +15,8 @@ public class NetworkAdapter {
     static let shared = NetworkAdapter()
     private init() {}
 
+    private let networkQueue = DispatchQueue(label: "com.zigsim.network")
+
     var tcpClient: TCPClient = TCPClient(
         address: AppSettingModel.shared.ipAddress,
         port: Int32(AppSettingModel.shared.portNumber)
@@ -28,17 +30,21 @@ public class NetworkAdapter {
 
     /// Send data over TCP / UDP automatically
     func send(_ data: Data) {
-        switch AppSettingModel.shared.transportProtocol {
-        case .TCP:
-            sendTCP(data)
-        case .UDP:
-            sendUDP(data)
+        networkQueue.async {
+            switch AppSettingModel.shared.transportProtocol {
+            case .TCP:
+                self.sendTCP(data)
+            case .UDP:
+                self.sendUDP(data)
+            }
         }
     }
 
     func close() {
-        udpClient.close()
-        tcpClient.close()
+        networkQueue.async {
+            self.udpClient.close()
+            self.tcpClient.close()
+        }
     }
 
     /// Get error description to show in output view
@@ -60,6 +66,8 @@ public class NetworkAdapter {
     }
 
     private func sendTCP(_ data: Data) {
+        assert(!Thread.isMainThread)
+
         let appSetting = AppSettingModel.shared
 
         // Recreate client
@@ -89,6 +97,8 @@ public class NetworkAdapter {
     }
 
     private func sendUDP(_ data: Data) {
+        assert(!Thread.isMainThread)
+
         let appSetting = AppSettingModel.shared
 
         // Recreate client


### PR DESCRIPTION
Linked Issue
- Closes #133

Summary
- Moves TCP/UDP socket work off the caller thread by serializing `NetworkAdapter.send(_:)` and `close()` onto a dedicated queue.
- Moves the `CommandPlayer` timer send path onto a background queue before handing work to `NetworkAdapter`.
- Adds `assert(!Thread.isMainThread)` at the TCP/UDP send boundaries to catch regressions during debug builds.

Scope
- `ZIGSIMPlus/Models/NetworkAdapter.swift`
- `ZIGSIMPlus/Models/CommandPlayer.swift`

Non-goals
- No transport protocol changes.
- No async/await migration.
- No signing, entitlement, or large workspace changes.

Changes
- Added `networkQueue` to `NetworkAdapter` and made `send(_:)` fire-and-forget on that queue.
- Serialized `close()` on the same queue to reduce races with queued sends.
- Added a `CommandPlayer` background queue for the timer-driven network send path.

Validation steps
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`\n\nResults\n- Command executed, but build did not compile in this environment. `xcodebuild` reported that CoreSimulator was unavailable and that `ZIGSIMPlus.xcworkspace` was not recognized as a valid workspace file in this branch checkout.\n- `git diff --check` passed.\n\nRisks\n- This changes send timing from synchronous caller-thread execution to queued background execution, so ordering now depends on queue serialization.\n- `close()` is asynchronous to avoid reintroducing main-thread blocking, so final shutdown timing should be verified on device.\n- The branch workspace metadata still references `Pods/Pods.xcodeproj`, which does not match the task note and blocks the requested workspace build here.\n\nDevice test requirements\n- needs-device-test\n- Required: verify 60fps command streaming does not freeze UI and confirm TCP/UDP send stability on a real device.