### PR TITLE
Issue #143: Match settings keyboard appearance to dark theme

### DIFF
--- a/ZIGSIMPlus/Views/CommandDetailSettingsViewController.swift
+++ b/ZIGSIMPlus/Views/CommandDetailSettingsViewController.swift
@@ -173,6 +173,7 @@ public class CommandDetailSettingsViewController: UIViewController {
 
         input.addTarget(self, action: #selector(uuidInputAction(input:)), for: .allEditingEvents)
         input.autocapitalizationType = .allCharacters
+        input.keyboardAppearance = .dark
 
         // Use DetailSettingKey for identifier
         input.tag = data.key.rawValue

--- a/ZIGSIMPlus/Views/CommandSetting.storyboard
+++ b/ZIGSIMPlus/Views/CommandSetting.storyboard
@@ -87,7 +87,7 @@
                                                     <constraint firstAttribute="width" constant="250" id="mLn-uN-Klm"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <textInputTraits key="textInputTraits" keyboardAppearance="default" keyboardType="numbersAndPunctuation" enablesReturnKeyAutomatically="YES"/>
+                                                <textInputTraits key="textInputTraits" keyboardAppearance="dark" keyboardType="numbersAndPunctuation" enablesReturnKeyAutomatically="YES"/>
                                             </textField>
                                             <label opaque="NO" userInteractionEnabled="NO" tag="3" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Port Number" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mGa-SP-GhO" customClass="ZIGLabel" customModule="ZIG_SIM_PRO" customModuleProvider="target">
                                                 <rect key="frame" x="122.33333333333334" y="250" width="98.333333333333343" height="21"/>
@@ -102,7 +102,7 @@
                                                     <constraint firstAttribute="height" constant="30" id="dZ3-OM-gac"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <textInputTraits key="textInputTraits" keyboardAppearance="default" keyboardType="numbersAndPunctuation" enablesReturnKeyAutomatically="YES"/>
+                                                <textInputTraits key="textInputTraits" keyboardAppearance="dark" keyboardType="numbersAndPunctuation" enablesReturnKeyAutomatically="YES"/>
                                             </textField>
                                             <label opaque="NO" userInteractionEnabled="NO" tag="4" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Message Format" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sS3-j7-8iF" userLabel="MESSAGE FORMAT" customClass="ZIGLabel" customModule="ZIG_SIM_PRO" customModuleProvider="target">
                                                 <rect key="frame" x="107.66666666666669" y="317" width="128" height="21"/>
@@ -159,7 +159,7 @@
                                                     <constraint firstAttribute="width" constant="250" id="6yF-iI-kRh"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <textInputTraits key="textInputTraits" keyboardAppearance="default" keyboardType="numbersAndPunctuation" enablesReturnKeyAutomatically="YES"/>
+                                                <textInputTraits key="textInputTraits" keyboardAppearance="dark" keyboardType="numbersAndPunctuation" enablesReturnKeyAutomatically="YES"/>
                                             </textField>
                                         </subviews>
                                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -3093,7 +3093,7 @@ Prescribed on June 17</string>
                                         </attributes>
                                     </fragment>
                                 </attributedString>
-                                <textInputTraits key="textInputTraits" keyboardAppearance="default" autocapitalizationType="sentences"/>
+                                <textInputTraits key="textInputTraits" keyboardAppearance="dark" autocapitalizationType="sentences"/>
                             </textView>
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/ZIGSIMPlus/Views/CommandSettingViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSettingViewController.swift
@@ -138,7 +138,7 @@ extension CommandSettingViewController: UITextFieldDelegate {
     private func setTextFieldSetting(texField: UITextField, text: String) {
         texField.text = String(text)
         texField.delegate = self
-        texField.keyboardAppearance = .default
+        texField.keyboardAppearance = .dark
 
         if texField.tag == 0 {
             texField.keyboardType = .asciiCapable


### PR DESCRIPTION
## Linked Issue
Closes #143

## Summary
Updates Settings-related text inputs to use the dark keyboard appearance so they match the app's dark UI theme.

## Scope
- Change `CommandSettingViewController` text field setup from `.default` to `.dark`
- Update `CommandSetting.storyboard` keyboard appearance for IP Address, Port Number, Device UUID, and Terms text view
- Set the programmatically created UUID input in `CommandDetailSettingsViewController` to `.dark`

## Non-goals
- No keyboard type changes
- No `UIUserInterfaceStyle` changes
- No `ZIGTextField` restyling
- No changes to other screens

## Changes
- Switched the Settings screen text field configuration to `.dark`
- Updated the four storyboard `textInputTraits` entries to `keyboardAppearance="dark"`
- Added `.dark` keyboard appearance to the detail UUID input created in code

## Validation Steps
- `xcodebuild -list -project ZIGSIMPlus.xcodeproj`
- `xcodebuild -project ZIGSIMPlus.xcodeproj -scheme ZIGSIMPlus -configuration Debug -destination 'generic/platform=iOS Simulator' build`

## Results
- `xcodebuild -list -project ZIGSIMPlus.xcodeproj`: passed
- `xcodebuild ... build`: failed during simulator link because `Private/Prototypes/NDISwift/ofxNDI/libs/NDI/lib/ios/libndi_ios.a` is built for iOS device, not iOS Simulator
- No issue-specific compile or storyboard errors were reported before that link failure

## Risks
- Storyboard and code both define keyboard appearance for some fields; they are now aligned, but future edits need to keep both in sync
- Real-device behavior still needs manual confirmation on the affected fields
- Existing simulator build validation is blocked by the unrelated NDI static library linker issue noted above

## Device Test Requirements
- `needs-device-test`
- Required: verify on device that IP Address, Port Number, Device UUID, Terms text view, and the detail UUID input all present the dark keyboard
