### PR TITLE
Add weak self to MotionService motion updates

### DIFF
--- a/ZIGSIMPlus/Models/Services/MotionService.swift
+++ b/ZIGSIMPlus/Models/Services/MotionService.swift
@@ -35,7 +35,8 @@ public class MotionService {
             return
         }
 
-        motionManager.startDeviceMotionUpdates(to: OperationQueue.current!) { deviceMotion, error in
+        motionManager.startDeviceMotionUpdates(to: OperationQueue.main) { [weak self] deviceMotion, error in
+            guard let self = self else { return }
             guard error == nil,
                 let motion = deviceMotion else {
                 self.isError = true


### PR DESCRIPTION
Linked Issue

Closes #149

Summary

Updates `MotionService.start()` so the `startDeviceMotionUpdates` callback does not retain `MotionService` strongly and no longer force-unwraps `OperationQueue.current`.

Scope

- `ZIGSIMPlus/Models/Services/MotionService.swift`
- Motion update callback capture and callback queue only

Non-goals

- No changes to motion data processing logic
- No `CMMotionManager` configuration changes
- No `MotionService` design changes
- No signing, entitlement, dependency, storyboard, or xib changes

Changes

- Replaced `OperationQueue.current!` with `OperationQueue.main` based on the visible UI/app lifecycle call path.
- Added `[weak self]` to the motion update closure.
- Added `guard let self = self else { return }` before accessing `isError` and `updateMotion(_:)`.

Validation commands

- `xcodebuild -list -workspace ZIGSIMPlus.xcworkspace`
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO build`

Results

- Scheme listing succeeded.
- Generic iOS build succeeded.
- Build emitted pre-existing SwiftLint warnings in unrelated files and asset/debug-symbol warnings, but no build failure.

Risks

- Low risk. `OperationQueue.main` is a deliberate replacement for the force-unwrapped current queue and matches the observed call path from UI/app lifecycle code.
- The validation build initially needed elevated local Xcode access because the sandbox could not access simulator/Xcode metadata.

Device testing requirement

- needs-device-test: Not required by issue #149; optional real-device smoke testing may be useful for motion sensor runtime behavior because simulator validation is not sufficient for sensor behavior.