### PR TITLE
Fix LocationService authorization check

### DIFF
--- a/ZIGSIMPlus/Models/Services/LocationService.swift
+++ b/ZIGSIMPlus/Models/Services/LocationService.swift
@@ -159,7 +159,7 @@ extension LocationService: CLLocationManagerDelegate {
 
     // Called when the user authorized monitorin location data
     public func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
-        if status != .authorizedAlways || status != .authorizedWhenInUse {
+        if status != .authorizedAlways && status != .authorizedWhenInUse {
             // TODO: Show error message
         }
     }


### PR DESCRIPTION
Linked Issue

Closes #146

Summary

Fixes the `LocationService` authorization guard so the TODO error path only matches statuses that are neither `.authorizedAlways` nor `.authorizedWhenInUse`.

Scope

- Changed the boolean operator in `ZIGSIMPlus/Models/Services/LocationService.swift` from `||` to `&&`.

Non-goals

- Did not implement the TODO error message.
- Did not change the location permission flow.
- Did not update delegate method signatures or iOS availability behavior.
- Did not modify any other tracked files.

Changes

- `status != .authorizedAlways && status != .authorizedWhenInUse` now correctly evaluates false for authorized statuses and true for unauthorized statuses such as `.denied`.

Validation commands

- `xcodebuild -list -workspace ZIGSIMPlus.xcworkspace`
- `xcodebuild -list -project ZIGSIMPlus.xcodeproj`
- `xcodebuild -project ZIGSIMPlus.xcodeproj -scheme ZIGSIMPlus -configuration Debug -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO build`

Results

- `xcodebuild -list -workspace ZIGSIMPlus.xcworkspace` failed locally before build validation; Xcode reported CoreSimulator/sandbox log-access errors and `ZIGSIMPlus.xcworkspace` was not recognized as a workspace file in that invocation.
- `xcodebuild -list -project ZIGSIMPlus.xcodeproj` succeeded and showed the `ZIGSIMPlus` scheme.
- First generic iOS build attempt in the isolated temp worktree failed because ignored/local private build input `Private/VideoCapture/CompositeRGBWithAlpha.metal` was absent from that worktree.
- After copying local ignored `Private` build inputs into the temp worktree for validation only, the same generic iOS build succeeded with existing warnings.

Risks

- Low. This is a one-character boolean logic fix.
- Existing build warnings remain, including SwiftLint TODO warnings and iOS deprecation warnings in `LocationService.swift`.

Device testing requirement

- Device testing not required for this logic-only change per issue #146. Simulator/device runtime verification remains optional.