### PR TITLE
Fix altimeter callback nil handling

### DIFF
--- a/ZIGSIMPlus/Models/Services/AltimeterService.swift
+++ b/ZIGSIMPlus/Models/Services/AltimeterService.swift
@@ -57,13 +57,18 @@ public class AltimeterService {
         if #available(iOS 8.0, *) {
             if CMAltimeter.isRelativeAltitudeAvailable() {
                 isWorking = true
-                altimeter.startRelativeAltitudeUpdates(to: OperationQueue.main, withHandler: { data, error in
-                    if error == nil {
-                        self.pressureData = Double(truncating: data!.pressure) * 10.0
-                        self.altitudeData = Double(truncating: data!.relativeAltitude)
-                        self.updateAltimeterData()
+                altimeter.startRelativeAltitudeUpdates(
+                    to: OperationQueue.main,
+                    withHandler: { [weak self] data, error in
+                        guard let self = self else { return }
+                        if error == nil {
+                            guard let data = data else { return }
+                            self.pressureData = Double(truncating: data.pressure) * 10.0
+                            self.altitudeData = Double(truncating: data.relativeAltitude)
+                            self.updateAltimeterData()
+                        }
                     }
-                })
+                )
             }
         } else {
             // Fallback on earlier versions


### PR DESCRIPTION
## Linked Issue

Closes #148

## Summary

Adds weak self capture to `AltimeterService.startAltimeter()` and safely unwraps `CMAltitudeData` before reading pressure and relative altitude.

## Scope

- Updated only `ZIGSIMPlus/Models/Services/AltimeterService.swift`.
- Changed the `startRelativeAltitudeUpdates` callback capture and optional handling.

## Non-goals

- Did not change pressure or altitude calculation logic.
- Did not remove the existing `#available(iOS 8.0, *)` check.
- Did not redesign `AltimeterService`.
- Did not touch signing, provisioning, entitlements, permissions, storyboards, xibs, secrets, or dependencies.

## Changes

- Added `[weak self]` to the altimeter callback capture list.
- Added `guard let self = self else { return }` before instance access.
- Replaced `data!` access with `guard let data = data else { return }` and direct `data.pressure` / `data.relativeAltitude` reads.

## Validation commands

- `xcodebuild -list -project ZIGSIMPlus.xcodeproj -clonedSourcePackagesDirPath /tmp/ZIGSIMPlus_issue148_SourcePackages`
- `/tmp/ZIGSIMPlus_issue148_SourcePackages/artifacts/swiftlint/SwiftLintBinary/SwiftLintBinary.artifactbundle/macos/swiftlint lint --quiet --force-exclude --config .swiftlint.yml --cache-path /tmp/ZIGSIMPlus_issue148_swiftlint_cache ZIGSIMPlus/Models/Services/AltimeterService.swift`
- `xcodebuild build -project ZIGSIMPlus.xcodeproj -scheme ZIGSIMPlus -configuration Debug -destination generic/platform=iOS -clonedSourcePackagesDirPath /tmp/ZIGSIMPlus_issue148_SourcePackages -derivedDataPath /tmp/ZIGSIMPlus_issue148_DerivedData CODE_SIGNING_ALLOWED=NO`

## Results

- Project listing succeeded and resolved Swift Package dependencies.
- SwiftLint on `AltimeterService.swift` passed.
- Build did not complete: it failed on existing missing build input `Private/VideoCapture/CompositeRGBWithAlpha.metal` in target `ZIGSIMPlus`. The final rerun showed SwiftLint warnings only in pre-existing unrelated files and no `AltimeterService.swift` lint warning.

## Risks

Low. The change is limited to callback capture and optional unwrapping. Runtime behavior should remain the same when altimeter data is present.

## Device testing requirement

Device testing is not required for this issue. Real-device altimeter runtime validation is optional; no device validation was performed.