### PR TITLE
Fix force unwraps in LocationService

### DIFF
--- a/ZIGSIMPlus/Models/Services/LocationService.swift
+++ b/ZIGSIMPlus/Models/Services/LocationService.swift
@@ -124,8 +124,10 @@ public class LocationService: NSObject {
 
 extension LocationService: CLLocationManagerDelegate {
     public final func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        latitudeData = (locations.last?.coordinate.latitude)!
-        longitudeData = (locations.last?.coordinate.longitude)!
+        guard let location = locations.last else { return }
+
+        latitudeData = location.coordinate.latitude
+        longitudeData = location.coordinate.longitude
     }
 
     public func locationManager(_ manager: CLLocationManager, didUpdateHeading newHeading: CLHeading) {
@@ -149,10 +151,10 @@ extension LocationService: CLLocationManagerDelegate {
                 $0.proximityUUID == beacon.proximityUUID && $0.major == beacon.major && $0.minor == beacon.minor
             })
 
-            if index == nil {
-                beacons.append(beacon)
+            if let index = index {
+                beacons[index] = beacon
             } else {
-                beacons[index!] = beacon
+                beacons.append(beacon)
             }
         }
     }


### PR DESCRIPTION
## Linked Issue

Closes #147

## Summary

Replaced two force unwraps in `LocationService` with optional binding so empty location updates and beacon index handling avoid crash-prone unwraps.

## Scope

- `LocationService.locationManager(_:didUpdateLocations:)`
- `LocationService.locationManager(_:didRangeBeacons:in:)`

## Non-goals

- Did not refactor the broader location service logic.
- Did not change `CLLocationManager` configuration.
- Did not change beacon management behavior beyond removing the force unwrap.
- Did not modify signing, provisioning, entitlements, permissions, storyboards, or xibs.

## Changes

- Added `guard let location = locations.last else { return }` before updating latitude/longitude.
- Replaced `beacons[index!] = beacon` with `if let index = index { beacons[index] = beacon }`.

## Validation Commands

- `xcodebuild -list -project ZIGSIMPlus.xcodeproj -clonedSourcePackagesDirPath /tmp/zigsim-issue147-spm`
- `git submodule update --init Private`
- `xcodebuild -project ZIGSIMPlus.xcodeproj -scheme ZIGSIMPlus -configuration Debug -destination generic/platform=iOS -derivedDataPath /tmp/zigsim-issue147-dd -clonedSourcePackagesDirPath /tmp/zigsim-issue147-spm CODE_SIGNING_ALLOWED=NO build`

## Results

- Project scheme listing succeeded and confirmed the `ZIGSIMPlus` scheme.
- First build attempt failed because the isolated worktree had the `Private` submodule uninitialized and was missing `Private/VideoCapture/CompositeRGBWithAlpha.metal`.
- After initializing `Private`, the build succeeded.
- Build output included existing SwiftLint, asset catalog, script phase, and license warnings unrelated to this change.

## Risks

Low. The change is limited to optional handling in two existing delegate methods and should preserve existing behavior for non-empty location arrays and matched beacons.

## Device Testing Requirement

Device testing is not required for this pattern-only replacement. Runtime GPS/iBeacon behavior can be optionally checked on device, but this PR does not require `needs-device-test`.
