### PR TITLE
Add weak self to CommandSetting observers

### DIFF
--- a/ZIGSIMPlus/Views/CommandSettingViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSettingViewController.swift
@@ -169,14 +169,16 @@ extension CommandSettingViewController: ContentScrollable {
             forName: UIResponder.keyboardWillShowNotification,
             object: nil,
             queue: nil
-        ) { notification in
+        ) { [weak self] notification in
+            guard let self = self else { return }
             self.keyboardWillShow(notification)
         }
         hideObserver = NotificationCenter.default.addObserver(
             forName: UIResponder.keyboardWillHideNotification,
             object: nil,
             queue: nil
-        ) { notification in
+        ) { [weak self] notification in
+            guard let self = self else { return }
             self.keyboardWillHide(notification)
         }
     }


### PR DESCRIPTION
Linked Issue

Closes #150

Summary

Adds weak self capture to the two keyboard NotificationCenter observer closures in CommandSettingViewController so the observer closures do not strongly retain the view controller while registered.

Scope

- Updated showObserver closure capture in configureObserver().
- Updated hideObserver closure capture in configureObserver().

Non-goals

- Did not change keyboard notification handling logic.
- Did not change removeObserver timing or observer lifecycle.
- Did not change NotificationCenter usage outside CommandSettingViewController.
- Did not change signing, entitlements, build settings, dependencies, storyboards, or xibs.

Changes

- Added [weak self] to both NotificationCenter closure capture lists.
- Added guard let self = self else { return } in both closures before calling the existing keyboard handlers.

Validation commands

- xcodebuild -list -workspace ZIGSIMPlus.xcworkspace
- xcodebuild -list -project ZIGSIMPlus.xcodeproj
- xcodebuild build -project ZIGSIMPlus.xcodeproj -scheme ZIGSIMPlusTests -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/zigsim-issue150-derivedData
- xcodebuild build -project ZIGSIMPlus.xcodeproj -scheme ZIGSIMPlus -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/zigsim-issue150-derivedData
- git submodule update --init Private
- xcodebuild build -project ZIGSIMPlus.xcodeproj -scheme ZIGSIMPlus -destination 'generic/platform=iOS' -derivedDataPath /tmp/zigsim-issue150-derivedData-ios CODE_SIGNING_ALLOWED=NO

Results

- Workspace listing failed with: xcodebuild: error: 'ZIGSIMPlus.xcworkspace' is not a workspace file.
- Project listing succeeded and showed schemes: OSCKit, swift-ascii, swift-data-parsing, ZIGSIMPlus, ZIGSIMPlusTests.
- ZIGSIMPlusTests simulator build did not compile because the scheme had no matching generic iOS Simulator destination.
- ZIGSIMPlus simulator build compiled the changed Swift file but failed at link because the private NDI iOS static library was linked into an iOS Simulator build.
- Initialized the Private submodule in the isolated worktree for validation.
- ZIGSIMPlus generic iOS build with CODE_SIGNING_ALLOWED=NO succeeded.
- Build emitted existing warnings, including SwiftLint warnings in files outside this issue scope and the existing CommandSettingViewController notification_center_detachment warning around removeObserver, which Issue #150 explicitly leaves unchanged.

Risks

Low. The change only weakens closure capture and preserves the existing keyboard handler calls and observer removal behavior. If self is released before a queued notification closure runs, the closure now returns instead of retaining the controller.

Device testing requirement

Device testing not required for Issue #150. No device validation was performed.