### PR TITLE
Replace TCP semaphores with async waits

### DIFF
--- a/ZIGSIMPlus/Models/CommandPlayer.swift
+++ b/ZIGSIMPlus/Models/CommandPlayer.swift
@@ -19,7 +19,7 @@ public class CommandPlayer {
     private init() {}
 
     private var updatingTimer: Timer?
-    private let networkQueue = DispatchQueue(label: "com.zigsim.commandPlayer.network")
+    private var networkSendTask: Task<Void, Never>?
     public var onUpdate: (() -> Void)?
     private var state: CommandPlayerState = .stopped
 
@@ -124,8 +124,16 @@ public class CommandPlayer {
 
     private func enqueueNetworkSend() {
         let data = ServiceManager.shared.getData()
-        networkQueue.async {
-            NetworkAdapter.shared.send(data)
+        let previousTask = networkSendTask
+
+        networkSendTask = Task.detached { [previousTask] in
+            await previousTask?.value
+
+            do {
+                try await NetworkAdapter.shared.send(data)
+            } catch {
+                // NetworkAdapter stores the mapped error for ServiceManager.getErrorLog().
+            }
         }
     }
 }

--- a/ZIGSIMPlus/Models/NetworkAdapter.swift
+++ b/ZIGSIMPlus/Models/NetworkAdapter.swift
@@ -18,7 +18,6 @@ public class NetworkAdapter {
     private var currentTCPAddress: String = ""
     private var currentTCPPort: Int = 0
 
-    private let networkQueue = DispatchQueue(label: "com.zigsim.network")
     private let connectionQueue = DispatchQueue(label: "com.zigsim.network.connection")
 
     var error: Error?
@@ -30,14 +29,52 @@ public class NetworkAdapter {
         case unknownError
     }
 
+    private final class ConnectionContinuationGate: @unchecked Sendable {
+        private let lock = NSLock()
+        private var continuation: CheckedContinuation<Void, Error>?
+
+        init(_ continuation: CheckedContinuation<Void, Error>) {
+            self.continuation = continuation
+        }
+
+        @discardableResult
+        func resume(returning value: Void = ()) -> Bool {
+            lock.lock()
+            guard let continuation = continuation else {
+                lock.unlock()
+                return false
+            }
+            self.continuation = nil
+            lock.unlock()
+
+            continuation.resume(returning: value)
+            return true
+        }
+
+        @discardableResult
+        func resume(throwing error: Error) -> Bool {
+            lock.lock()
+            guard let continuation = continuation else {
+                lock.unlock()
+                return false
+            }
+            self.continuation = nil
+            lock.unlock()
+
+            continuation.resume(throwing: error)
+            return true
+        }
+    }
+
     /// Send data over TCP / UDP automatically
-    func send(_ data: Data) {
-        networkQueue.async {
-            switch AppSettingModel.shared.transportProtocol {
-            case .TCP:
-                self.sendTCP(data)
-            case .UDP:
-                self.sendUDP(data)
+    func send(_ data: Data) async throws {
+        switch AppSettingModel.shared.transportProtocol {
+        case .TCP:
+            try await sendTCP(data)
+        case .UDP:
+            sendUDP(data)
+            if let error = error {
+                throw error
             }
         }
     }
@@ -69,7 +106,7 @@ public class NetworkAdapter {
         return false
     }
 
-    private func sendTCP(_ data: Data) {
+    private func sendTCP(_ data: Data) async throws {
         assert(!Thread.isMainThread)
 
         let appSetting = AppSettingModel.shared
@@ -88,66 +125,74 @@ public class NetworkAdapter {
         if !isTCPReady {
             guard let nwPort = NWEndpoint.Port(rawValue: UInt16(port)) else {
                 error = NetworkError.queryFailed
-                return
+                throw NetworkError.queryFailed
             }
 
             let conn = NWConnection(host: NWEndpoint.Host(address), port: nwPort, using: .tcp)
             tcpConnection = conn
 
-            let semaphore = DispatchSemaphore(value: 0)
-            var connectError: Error?
-
-            conn.stateUpdateHandler = { state in
-                switch state {
-                case .ready:
-                    semaphore.signal()
-                case .failed(let err):
-                    connectError = err
-                    semaphore.signal()
-                case .cancelled:
-                    connectError = NetworkError.connectionClosed
-                    semaphore.signal()
-                default:
-                    break
-                }
-            }
-            conn.start(queue: connectionQueue)
-
-            if semaphore.wait(timeout: .now() + 1.0) == .timedOut {
-                conn.cancel()
+            do {
+                try await connectTCP(conn)
+            } catch {
                 tcpConnection = nil
-                error = NetworkError.connectionTimeout
-                return
-            }
-
-            if let err = connectError {
-                tcpConnection = nil
-                error = mapNWError(err)
-                return
+                let networkError = mapNetworkError(error)
+                self.error = networkError
+                throw networkError
             }
         }
 
         guard let conn = tcpConnection, isTCPReady else {
             tcpConnection = nil
             error = NetworkError.connectionClosed
-            return
+            throw NetworkError.connectionClosed
         }
 
-        let semaphore = DispatchSemaphore(value: 0)
-        var sendError: Error?
-
-        conn.send(content: data, completion: .contentProcessed { nwError in
-            sendError = nwError
-            semaphore.signal()
-        })
-
-        semaphore.wait()
-
-        if let err = sendError {
-            tcpConnection = nil
-            error = mapNWError(err)
-        } else {
+        do {
+            try await sendTCP(data, on: conn)
             error = nil
+        } catch {
+            tcpConnection = nil
+            let networkError = mapNetworkError(error)
+            self.error = networkError
+            throw networkError
+        }
+    }
+
+    private func connectTCP(_ conn: NWConnection) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            let gate = ConnectionContinuationGate(continuation)
+
+            conn.stateUpdateHandler = { state in
+                switch state {
+                case .ready:
+                    gate.resume()
+                case .failed(let err):
+                    gate.resume(throwing: err)
+                case .cancelled:
+                    gate.resume(throwing: NetworkError.connectionClosed)
+                default:
+                    break
+                }
+            }
+            conn.start(queue: connectionQueue)
+
+            connectionQueue.asyncAfter(deadline: .now() + 1.0) {
+                if gate.resume(throwing: NetworkError.connectionTimeout) {
+                    conn.cancel()
+                }
+            }
+        }
+    }
+
+    private func sendTCP(_ data: Data, on conn: NWConnection) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            conn.send(content: data, completion: .contentProcessed { nwError in
+                if let nwError = nwError {
+                    continuation.resume(throwing: nwError)
+                } else {
+                    continuation.resume()
+                }
+            })
         }
     }
 
@@ -170,7 +215,7 @@ public class NetworkAdapter {
         let semaphore = DispatchSemaphore(value: 0)
         var sendError: Error?
 
-        conn.stateUpdateHandler = { [weak self] state in
+        conn.stateUpdateHandler = { state in
             switch state {
             case .ready:
                 conn.send(content: data, completion: .contentProcessed { nwError in
@@ -211,5 +256,12 @@ public class NetworkAdapter {
         default:
             return .unknownError
         }
+    }
+
+    private func mapNetworkError(_ err: Error) -> NetworkError {
+        if let networkError = err as? NetworkError {
+            return networkError
+        }
+        return mapNWError(err)
     }
 }


### PR DESCRIPTION
## Linked Issue

Closes #151

## Summary

Replace the TCP `DispatchSemaphore` waits in `NetworkAdapter` with async/await continuations so TCP connect and send completion no longer block a dispatch queue thread.

## Scope

- TCP connection establishment wait in `NetworkAdapter`
- TCP send completion wait in `NetworkAdapter`
- `NetworkAdapter.send(_:)` async/throws propagation
- `CommandPlayer` network send call site

## Non-goals

- UDP send semaphore migration; the UDP path still has its existing semaphore and should be handled separately if desired.
- `NWConnection` lifecycle redesign beyond the existing connect/reuse behavior.
- Timeout value changes.
- Error-handling redesign beyond preserving existing mapped `NetworkError` values.

## Changes

- Added a lock-protected one-shot continuation gate so TCP state updates and the 1.0s timeout cannot resume the checked continuation more than once.
- Converted TCP connect and TCP send waits to `withCheckedThrowingContinuation`.
- Made `NetworkAdapter.send(_:)` `async throws`.
- Updated `CommandPlayer` to chain network send tasks asynchronously instead of blocking a serial dispatch queue while each send completes.

## Validation Commands

- `xcodebuild -list -workspace ZIGSIMPlus.xcworkspace`
- `xcodebuild -quiet -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -sdk iphonesimulator -configuration Debug CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -quiet -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -configuration Debug -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -quiet -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlusTests -sdk iphonesimulator -configuration Debug CODE_SIGNING_ALLOWED=NO build-for-testing`

## Results

- Workspace scheme listing succeeded.
- Generic iOS app build succeeded with existing warnings.
- iOS simulator app build failed at link time because `Private/Prototypes/NDISwift/ofxNDI/libs/NDI/lib/ios/libndi_ios.a` is built for iOS, not iOS simulator. Swift compilation passed before that link failure.
- iOS simulator test build failed for the same NDI iOS-vs-simulator link issue, so tests were not executed.

## Risks

- Medium: TCP networking now crosses Swift concurrency boundaries, and `NWConnection.stateUpdateHandler` can emit multiple states. The continuation gate is intended to keep resumes single-shot.
- UDP still uses its existing semaphore because it is out of scope for this issue.
- Send sequencing is preserved at the `CommandPlayer` call site by chaining tasks, but this should be checked under real 60fps device load.

## Device Testing Requirement

needs-device-test

Real-device validation is required for 60fps sensor-data TCP sending and UI smoothness. I did not perform real-device performance validation.