### PR TITLE
Fix safe volume change handling

### DIFF
--- a/ZIGSIMPlus/Models/Services/RemoteControlService.swift
+++ b/ZIGSIMPlus/Models/Services/RemoteControlService.swift
@@ -41,8 +41,11 @@ public class RemoteControlService: NSObject {
     }
 
     @objc func onVolumeChange(notification: NSNotification) {
-        // swiftlint:disable:next force_cast
-        volume = notification.userInfo!["AVSystemController_AudioVolumeNotificationParameter"] as! Double
+        guard let userInfo = notification.userInfo,
+              let value = userInfo["AVSystemController_AudioVolumeNotificationParameter"] as? Double else {
+            return
+        }
+        volume = value
     }
 
     @objc func onTogglePlayPause(_ event: MPRemoteCommandEvent) -> MPRemoteCommandHandlerStatus {


### PR DESCRIPTION
## Linked Issue

Closes #158

## Summary

Safely handles the system volume notification payload in `RemoteControlService.onVolumeChange` by replacing the force unwrap and force cast with optional binding.

## Scope

- Updated only `ZIGSIMPlus/Models/Services/RemoteControlService.swift`.
- Kept existing volume change behavior when the expected `Double` payload is present.
- Skips updating `volume` when `userInfo` is missing, the key is absent, or the value is not a `Double`.

## Non-goals

- Did not change the broader remote control or volume update logic.
- Did not investigate or replace the private API notification key.
- Did not redesign `RemoteControlService`.
- Did not change signing, provisioning, entitlements, permissions, storyboards, XIBs, dependencies, or build settings.

## Changes

- Removed the `swiftlint:disable:next force_cast` suppression.
- Replaced `notification.userInfo!` with guarded optional binding.
- Replaced `as! Double` with `as? Double`.
- Added an early `return` when the notification payload is unavailable or type-mismatched.

## Validation Commands

- `xcodebuild -list -workspace ZIGSIMPlus.xcworkspace`
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO build`

## Results

- Workspace schemes listed successfully.
- Generic iOS build completed successfully with `** BUILD SUCCEEDED **`.
- Existing warnings were emitted by SwiftLint, asset catalog processing, license plist generation, and dSYM/module cache handling. No new failure was observed.

## Risks

Low. The only behavior change is that malformed or missing volume notification payloads no longer crash and instead leave `volume` unchanged.

## Device Testing Requirement

Device testing is not required for Issue #158. No device validation was performed, and simulator/build validation is not being claimed as real-device validation.