### PR TITLE
Replace force casts in AppDelegate presenter composition

### DIFF
--- a/ZIGSIMPlus/AppDelegate.swift
+++ b/ZIGSIMPlus/AppDelegate.swift
@@ -37,8 +37,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private func composePresenters() {
         let factory = PresenterFactory()
 
-        // swiftlint:disable:next force_cast
-        let tabBarController = window?.rootViewController as! UITabBarController
+        guard let tabBarController = window?.rootViewController as? UITabBarController else {
+            assertionFailure("Root VC is not UITabBarController")
+            return
+        }
 
         // Setup tab bar styles directly on instance
         let tabBar = tabBarController.tabBar
@@ -55,19 +57,25 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             //tabBar.barTintColor = Theme.dark
         }
 
-        for viewController in tabBarController.viewControllers! {
+        for viewController in tabBarController.viewControllers ?? [] {
             if type(of: viewController) == CommandSelectionTabNavigationController.self {
-                // swiftlint:disable:next force_cast
-                let vc = viewController as! CommandSelectionTabNavigationController
-                factory.createPresenter(parentView: vc, viewType: CommandSelectionViewController.self)
+                if let vc = viewController as? CommandSelectionTabNavigationController {
+                    factory.createPresenter(parentView: vc, viewType: CommandSelectionViewController.self)
+                } else {
+                    assertionFailure("Command selection tab is not CommandSelectionTabNavigationController")
+                }
             } else if type(of: viewController) == CommandOutputTabNavigationController.self {
-                // swiftlint:disable:next force_cast
-                let vc = viewController as! CommandOutputTabNavigationController
-                factory.createPresenter(parentView: vc, viewType: CommandOutputViewController.self)
+                if let vc = viewController as? CommandOutputTabNavigationController {
+                    factory.createPresenter(parentView: vc, viewType: CommandOutputViewController.self)
+                } else {
+                    assertionFailure("Command output tab is not CommandOutputTabNavigationController")
+                }
             } else if type(of: viewController) == CommandSettingTabNavigationController.self {
-                // swiftlint:disable:next force_cast
-                let vc = viewController as! CommandSettingTabNavigationController
-                factory.createPresenter(parentView: vc, viewType: CommandSettingViewController.self)
+                if let vc = viewController as? CommandSettingTabNavigationController {
+                    factory.createPresenter(parentView: vc, viewType: CommandSettingViewController.self)
+                } else {
+                    assertionFailure("Command setting tab is not CommandSettingTabNavigationController")
+                }
             }
         }
     }


### PR DESCRIPTION
Linked Issue

Closes #159

Summary

Replaces force casts in `AppDelegate.composePresenters()` with optional casts and debug assertions so storyboard/controller mismatches are detected during development without immediate `as!` crashes.

Scope

- Updated root view controller casting to `guard let ... as? UITabBarController` with `assertionFailure` and `return`.
- Updated command tab navigation controller casts to optional casting with `if let`.
- Replaced `tabBarController.viewControllers!` with `tabBarController.viewControllers ?? []`.
- Removed `swiftlint:disable force_cast` suppressions in `composePresenters()`.

Non-goals

- No storyboard changes.
- No `PresenterFactory` changes.
- No architecture changes.
- No signing, entitlement, permission, dependency, storyboard, or XIB configuration changes.

Changes

- `ZIGSIMPlus/AppDelegate.swift` only.

Validation commands

- `rg -n "as!|force_cast|viewControllers!" ZIGSIMPlus/AppDelegate.swift`
- `xcodebuild -list -workspace ZIGSIMPlus.xcworkspace`
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -destination 'generic/platform=iOS Simulator' build`
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`

Results

- `rg` found no remaining `as!`, `force_cast`, or `viewControllers!` in `AppDelegate.swift` after the change.
- Workspace scheme listing succeeded and confirmed the `ZIGSIMPlus` scheme.
- Simulator build failed at link because `libndi_ios.a` is built for iOS device, not iOS Simulator: `building for 'iOS-simulator', but linking in object file ... built for 'iOS'`.
- Generic iOS build with `CODE_SIGNING_ALLOWED=NO` succeeded in the full checkout.
- A repeat generic iOS build from a temporary isolated worktree failed because that worktree did not include private/untracked input `Private/VideoCapture/CompositeRGBWithAlpha.metal`; the branch diff itself remains limited to `AppDelegate.swift`.
- SwiftLint ran as part of the build and reported existing warnings; no force-cast warning remains in `composePresenters()`.

Risks

Low. If the storyboard root is not a `UITabBarController`, presenter composition now triggers `assertionFailure` and returns instead of crashing via force cast. If an expected command tab controller cannot be cast, presenter creation for that tab is skipped after `assertionFailure`.

Device testing requirement

Device testing is not required for this issue. No runtime device validation was performed.