### PR TITLE
Fix CommandPlayer timer retain cycle

### DIFF
--- a/ZIGSIMPlus/Models/CommandPlayer.swift
+++ b/ZIGSIMPlus/Models/CommandPlayer.swift
@@ -57,12 +57,11 @@ public class CommandPlayer {
 
     private func startCommands() {
         updatingTimer = Timer.scheduledTimer(
-            timeInterval: Utils.getMessageInterval(),
-            target: self,
-            selector: #selector(monitorCommands),
-            userInfo: nil,
+            withTimeInterval: Utils.getMessageInterval(),
             repeats: true
-        )
+        ) { [weak self] _ in
+            self?.monitorCommands()
+        }
 
         for command in Command.allCases {
             if isActive(command) {
@@ -81,7 +80,7 @@ public class CommandPlayer {
         onUpdate?()
     }
 
-    @objc private func monitorCommands() {
+    private func monitorCommands() {
         if isActive(.battery) {
             BatteryService.shared.updateBattery()
         }


### PR DESCRIPTION
## Linked Issue

Closes #161

## Summary

Replaces the repeating `CommandPlayer` timer setup with the block-based `Timer.scheduledTimer(withTimeInterval:repeats:block:)` API and captures `self` weakly to avoid the timer retaining `CommandPlayer` through a target-selector reference.

## Scope

- `ZIGSIMPlus/Models/CommandPlayer.swift`
- Timer setup in `startCommands()`
- Internal `monitorCommands()` invocation visibility

## Non-goals

- Did not change `CommandPlayer` singleton design.
- Did not change the timer interval.
- Did not replace `Timer` with Combine or another scheduling mechanism.
- Did not touch signing, entitlements, permissions, storyboard/xib files, or dependencies.

## Changes

- Replaced `Timer.scheduledTimer(timeInterval:target:selector:userInfo:repeats:)` with the closure-based overload.
- Added `[weak self]` in the timer closure.
- Removed the no-longer-needed `@objc` attribute from `monitorCommands()`.

## Validation Commands

```sh
xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -destination generic/platform=iOS -derivedDataPath /tmp/ZIGSIMPlusIssue161DeviceDerivedData CODE_SIGNING_ALLOWED=NO build
```

Additional attempted command:

```sh
xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -destination generic/platform=iOS\ Simulator -derivedDataPath /tmp/ZIGSIMPlusIssue161DerivedData build
```

## Results

- Generic iOS build succeeded with `CODE_SIGNING_ALLOWED=NO`.
- Simulator build was not suitable for final validation because the project links `Private/Prototypes/NDISwift/ofxNDI/libs/NDI/lib/ios/libndi_ios.a`, which is built for iOS device and fails when linked into an iOS Simulator build.
- SwiftLint ran as part of the Xcode build and reported existing warnings unrelated to this change.

## Risks

Low. The timer still repeats at `Utils.getMessageInterval()` and still calls `monitorCommands()`; only the retention behavior and invocation mechanism changed.

## Device Testing Requirement

Device testing is not required for Issue #161 per the issue notes. No real-device validation was performed.