### PR TITLE
Replace PresenterFactory force casts

### DIFF
--- a/ZIGSIMPlus/PresenterFactory.swift
+++ b/ZIGSIMPlus/PresenterFactory.swift
@@ -14,14 +14,17 @@ class PresenterFactory {
         for viewController in parentView.viewControllers {
             if type(of: viewController) == viewType {
                 if viewType == CommandSelectionViewController.self {
-                    let vc = viewController as! CommandSelectionViewController // swiftlint:disable:this force_cast
-                    vc.presenter = CommandSelectionPresenter(view: vc)
+                    if let vc = viewController as? CommandSelectionViewController {
+                        vc.presenter = CommandSelectionPresenter(view: vc)
+                    }
                 } else if viewType == CommandOutputViewController.self {
-                    let vc = viewController as! CommandOutputViewController // swiftlint:disable:this force_cast
-                    vc.presenter = CommandOutputPresenter(view: vc)
+                    if let vc = viewController as? CommandOutputViewController {
+                        vc.presenter = CommandOutputPresenter(view: vc)
+                    }
                 } else if viewType == CommandSettingViewController.self {
-                    let vc = viewController as! CommandSettingViewController // swiftlint:disable:this force_cast
-                    vc.presenter = CommandSettingPresenter(view: vc)
+                    if let vc = viewController as? CommandSettingViewController {
+                        vc.presenter = CommandSettingPresenter(view: vc)
+                    }
                 }
             }
         }
@@ -30,8 +33,9 @@ class PresenterFactory {
     func createVideoCapturePresenter(parentView: CommandOutputViewController) {
         for viewController in parentView.children {
             if type(of: viewController) == VideoCaptureViewController.self {
-                let vc = viewController as! VideoCaptureViewController // swiftlint:disable:this force_cast
-                vc.presenter = VideoCapturePresenter(view: vc)
+                if let vc = viewController as? VideoCaptureViewController {
+                    vc.presenter = VideoCapturePresenter(view: vc)
+                }
             }
         }
     }


### PR DESCRIPTION
Linked Issue
- Closes #160

Summary
- Replaced force casts in `PresenterFactory` with optional binding.
- Removed the `swiftlint:disable:this force_cast` comments from the affected cast sites.

Scope
- `ZIGSIMPlus/PresenterFactory.swift`
- `createPresenter`
- `createVideoCapturePresenter`

Non-goals
- No PresenterFactory generic redesign.
- No presenter architecture changes.
- No AppDelegate changes.
- No signing, provisioning, entitlement, storyboard, or xib changes.

Changes
- Converted casts for `CommandSelectionViewController`, `CommandOutputViewController`, `CommandSettingViewController`, and `VideoCaptureViewController` from `as!` to `as?` with `if let` binding.
- Preserved the existing `type(of:) == ...` checks and presenter assignment behavior.

Validation commands
- `rg "as!|force_cast" ZIGSIMPlus/PresenterFactory.swift`
- `git diff --check -- ZIGSIMPlus/PresenterFactory.swift`
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -sdk iphonesimulator -destination generic/platform=iOS\ Simulator CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -sdk iphoneos -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO build`

Results
- `rg "as!|force_cast" ZIGSIMPlus/PresenterFactory.swift`: no matches.
- `git diff --check -- ZIGSIMPlus/PresenterFactory.swift`: passed.
- Simulator build: failed at link due existing `libndi_ios.a` being built for iOS device, not iOS Simulator.
- Generic iOS build from the full checkout: passed with `CODE_SIGNING_ALLOWED=NO`.
- Generic iOS build from isolated `/tmp/zigsimplus-issue160` worktree: failed because private/untracked files such as `Private/VideoCapture/CompositeRGBWithAlpha.metal` were not present in that worktree. This is an environment/worktree limitation; the same command passed in the full checkout.

Risks
- Low. The existing exact type checks remain in place, and the new optional bindings only avoid force-cast crashes if a future mismatch occurs.
- SwiftLint still reports existing `for_where` warnings in `PresenterFactory`; those are out of scope for this issue.

Device testing requirement
- Device testing not required for this issue.
- No `needs-device-test` label requested.