### PR TITLE
Fix StandardCell outlet typo and casts

### DIFF
--- a/ZIGSIMPlus/Views/CommandSelectionViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSelectionViewController.swift
@@ -150,9 +150,9 @@ extension CommandSelectionViewController: UITableViewDataSource {
         cells[Command.allCases[indexPath.row]] = cell
 
         if AppSettingModel.shared.isActiveByCommand[Command.allCases[indexPath.row]] ?? false {
-            cell.checkMarkLavel.text = checkMark
+            cell.checkMarkLabel.text = checkMark
         } else {
-            cell.checkMarkLavel.text = ""
+            cell.checkMarkLabel.text = ""
         }
 
         if CommandAndServiceMediator.isAvailable(Command.allCases[indexPath.row]) {

--- a/ZIGSIMPlus/Views/CustomCells/StandardCell.swift
+++ b/ZIGSIMPlus/Views/CustomCells/StandardCell.swift
@@ -12,7 +12,7 @@ import UIKit
 public class StandardCell: UITableViewCell {
     @IBOutlet var commandOnOffButton: UIButton!
     @IBOutlet var commandLabel: UILabel!
-    @IBOutlet var checkMarkLavel: UILabel!
+    @IBOutlet var checkMarkLabel: UILabel!
     @IBOutlet var detailButton: UIButton!
     @IBOutlet var detailImageView: UIImageView!
     @IBOutlet var modalButton: UIButton!
@@ -21,9 +21,9 @@ public class StandardCell: UITableViewCell {
     var viewController: UIViewController!
 
     @IBAction func commandOnOffButtonAction(_ sender: UIButton) {
-        setCheckMarkLavelText()
+        setCheckMarkLabelText()
         setCommandsOfImageAvailability(sender)
-        if checkMarkLavel.text == checkMark {
+        if checkMarkLabel.text == checkMark {
             commandSelectionPresenter.saveCommandOnOffToUserDefaults(Command.allCases[sender.tag], true)
         } else {
             commandSelectionPresenter.saveCommandOnOffToUserDefaults(Command.allCases[sender.tag], false)
@@ -32,21 +32,19 @@ public class StandardCell: UITableViewCell {
     }
 
     @IBAction func detailButtonAction(_: UIButton) {
-        // swiftlint:disable:next force_cast
-        let parent = viewController as! CommandSelectionViewController
+        guard let parent = viewController as? CommandSelectionViewController else { return }
         parent.showDetail(commandNo: commandOnOffButton.tag)
     }
 
     @IBAction func modalButtonAction(_: UIButton) {
-        // swiftlint:disable:next force_cast
-        let parent = viewController as! CommandSelectionViewController
+        guard let parent = viewController as? CommandSelectionViewController else { return }
         parent.showModal(commandNo: commandLabel.tag)
     }
 
     func initCell() {
         backgroundColor = Theme.black
-        checkMarkLavel.textColor = Theme.main
-        checkMarkLavel.font = UIFont.boldSystemFont(ofSize: 23)
+        checkMarkLabel.textColor = Theme.main
+        checkMarkLabel.font = UIFont.boldSystemFont(ofSize: 23)
         modalButton.tintColor = Theme.main
         let screenWidth = UIScreen.main.bounds.size.width
         let newConstant = screenWidth - 195 // "195" is calibration constant adjusted to fit any devices.
@@ -54,11 +52,11 @@ public class StandardCell: UITableViewCell {
     }
 
     func setCommandsOfImageAvailability(_ sender: UIButton) {
-        let parent = viewController as! CommandSelectionViewController // swiftlint:disable:this force_cast
+        guard let parent = viewController as? CommandSelectionViewController else { return }
         if Command.allCases[sender.tag] == .ndi ||
             Command.allCases[sender.tag] == .arkit ||
             Command.allCases[sender.tag] == .imageDetection {
-            if checkMarkLavel.text == checkMark {
+            if checkMarkLabel.text == checkMark {
                 parent.setSelectedButtonAvailable(sender.tag)
             } else {
                 parent.setNdiArkitImageDetectionButtonAvailable()
@@ -66,11 +64,11 @@ public class StandardCell: UITableViewCell {
         }
     }
 
-    func setCheckMarkLavelText() {
-        if checkMarkLavel.text == "" {
-            checkMarkLavel.text = checkMark
+    func setCheckMarkLabelText() {
+        if checkMarkLabel.text == "" {
+            checkMarkLabel.text = checkMark
         } else {
-            checkMarkLavel.text = ""
+            checkMarkLabel.text = ""
         }
     }
 }

--- a/ZIGSIMPlus/Views/CustomCells/StandardCell.xib
+++ b/ZIGSIMPlus/Views/CustomCells/StandardCell.xib
@@ -94,7 +94,7 @@
             </tableViewCellContentView>
             <color key="backgroundColor" red="0.050951294600963593" green="0.047058552503585815" blue="0.047058872878551483" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
             <connections>
-                <outlet property="checkMarkLavel" destination="dIM-VS-hEA" id="xVq-al-hOv"/>
+                <outlet property="checkMarkLabel" destination="dIM-VS-hEA" id="xVq-al-hOv"/>
                 <outlet property="commandLabel" destination="Mgt-VT-WPX" id="jLs-bB-s63"/>
                 <outlet property="commandOnOffButton" destination="8T7-ur-Xt4" id="ZRM-vI-M4b"/>
                 <outlet property="detailButton" destination="0QB-qM-gp6" id="xgl-fM-TBx"/>


### PR DESCRIPTION
Linked Issue

Closes #170

Summary

Renames the misspelled StandardCell checkmark outlet from `checkMarkLavel` to `checkMarkLabel` and replaces StandardCell force casts to `CommandSelectionViewController` with guarded optional casts.

Scope

- `StandardCell` checkmark outlet name and internal references
- `CommandSelectionViewController` references to the renamed outlet
- `StandardCell.xib` outlet connection name
- Three StandardCell casts from `as!` to `as?` with `guard let`

Non-goals

- Did not change `viewController: UIViewController!` ownership or introduce a delegate pattern
- Did not change `StandardCell` responsibilities or architecture
- Did not address the existing magic number `195`
- Did not modify signing, provisioning, entitlements, permissions, secrets, dependencies, or build settings

Changes

- Renamed `checkMarkLavel` to `checkMarkLabel` in Swift references and the xib outlet connection
- Renamed the helper method to `setCheckMarkLabelText` to keep the corrected name consistent
- Replaced the three forced `CommandSelectionViewController` casts in `StandardCell` with `guard let parent = viewController as? CommandSelectionViewController else { return }`
- Removed the SwiftLint `force_cast` suppression comments that were tied to those forced casts

Validation commands

- `rg -n "checkMarkLavel|setCheckMarkLavelText|as! CommandSelectionViewController" ZIGSIMPlus`
- `git diff --check -- ZIGSIMPlus/Views/CustomCells/StandardCell.swift ZIGSIMPlus/Views/CommandSelectionViewController.swift ZIGSIMPlus/Views/CustomCells/StandardCell.xib`
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -destination 'generic/platform=iOS Simulator' build`
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`

Results

- Search found no remaining `checkMarkLavel`, `setCheckMarkLavelText`, or `as! CommandSelectionViewController` references under `ZIGSIMPlus`
- `git diff --check` passed for the touched files
- Simulator build failed at link because `Private/Prototypes/NDISwift/ofxNDI/libs/NDI/lib/ios/libndi_ios.a` is built for device iOS and cannot link into an iOS simulator target
- Generic device build with code signing disabled succeeded
- Xcode compiled `StandardCell.xib` during the successful device build
- Existing SwiftLint/build warnings remain outside this issue scope

Risks

- Low risk. The main risk is Interface Builder outlet wiring; the xib connection was updated and compiled in the device build.
- The guarded casts now return early if `viewController` is not a `CommandSelectionViewController`, avoiding crashes but also skipping the action in that invalid configuration.

Device testing requirement

- Device behavior change is not expected for this issue.
- Real-device validation is still recommended before release for this iOS project and to confirm the StandardCell UI wiring in the running app.
- `needs-device-test`