### PR TITLE
Simplify AltimeterService availability handling

### DIFF
--- a/ZIGSIMPlus/Models/Services/AltimeterService.swift
+++ b/ZIGSIMPlus/Models/Services/AltimeterService.swift
@@ -17,7 +17,7 @@ public class AltimeterService {
 
     // MARK: - Instance Properties
 
-    var altimeter: AnyObject!
+    var altimeter = CMAltimeter()
     var isWorking: Bool
     var pressureData: Double
     var altitudeData: Double
@@ -28,11 +28,6 @@ public class AltimeterService {
         pressureData = 0.0
         altitudeData = 0.0
         callbackAltimeter = nil
-        if #available(iOS 8.0, *) {
-            altimeter = CMAltimeter()
-        } else {
-            altimeter = false as AnyObject
-        }
     }
 
     private func updateAltimeterData() {
@@ -47,31 +42,24 @@ public class AltimeterService {
     // MARK: - Public methods
 
     func isAvailable() -> Bool {
-        if #available(iOS 8.0, *) {
-            return CMAltimeter.isRelativeAltitudeAvailable()
-        }
-        return false
+        return CMAltimeter.isRelativeAltitudeAvailable()
     }
 
     func startAltimeter() {
-        if #available(iOS 8.0, *) {
-            if CMAltimeter.isRelativeAltitudeAvailable() {
-                isWorking = true
-                altimeter.startRelativeAltitudeUpdates(
-                    to: OperationQueue.main,
-                    withHandler: { [weak self] data, error in
-                        guard let self = self else { return }
-                        if error == nil {
-                            guard let data = data else { return }
-                            self.pressureData = Double(truncating: data.pressure) * 10.0
-                            self.altitudeData = Double(truncating: data.relativeAltitude)
-                            self.updateAltimeterData()
-                        }
+        if CMAltimeter.isRelativeAltitudeAvailable() {
+            isWorking = true
+            altimeter.startRelativeAltitudeUpdates(
+                to: OperationQueue.main,
+                withHandler: { [weak self] data, error in
+                    guard let self = self else { return }
+                    if error == nil {
+                        guard let data = data else { return }
+                        self.pressureData = Double(truncating: data.pressure) * 10.0
+                        self.altitudeData = Double(truncating: data.relativeAltitude)
+                        self.updateAltimeterData()
                     }
-                )
-            }
-        } else {
-            // Fallback on earlier versions
+                }
+            )
         }
     }
 


### PR DESCRIPTION
Linked Issue

Closes #166

Summary

- Simplifies `AltimeterService` for the current iOS baseline by using a concrete `CMAltimeter` property.
- Removes obsolete iOS 8 availability guards and the `false as AnyObject` fallback.

Scope

- `ZIGSIMPlus/Models/Services/AltimeterService.swift` only.

Non-goals

- Did not change the altimeter callback behavior.
- Did not redesign `AltimeterService`.
- Did not change signing, provisioning, entitlements, permissions, storyboards, xibs, dependencies, or build settings.

Changes

- Replaced `var altimeter: AnyObject!` with `var altimeter = CMAltimeter()`.
- Removed `init()` altimeter availability branching.
- Simplified `isAvailable()` to return `CMAltimeter.isRelativeAltitudeAvailable()` directly.
- Removed the iOS 8 guard and fallback branch from `startAltimeter()`.

Validation commands

- `xcodebuild -list -workspace ZIGSIMPlus.xcworkspace`
- `rg "#available\\(iOS 8\\.0|AnyObject|false as AnyObject" ZIGSIMPlus/Models/Services/AltimeterService.swift`
- `git submodule update --init Private`
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -destination generic/platform=iOS\\ Simulator build`
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO build`

Results

- Workspace schemes listed successfully.
- Targeted `rg` check returned no matches for obsolete iOS 8 availability, `AnyObject`, or `false as AnyObject` in `AltimeterService.swift`.
- Initial simulator build failed before final validation because the clean worktree had the `Private` submodule uninitialized and `Private/VideoCapture/CompositeRGBWithAlpha.metal` was missing.
- After initializing `Private`, simulator build compiled through the touched file but failed at link because `Private/Prototypes/NDISwift/ofxNDI/libs/NDI/lib/ios/libndi_ios.a` is built for iOS, not iOS Simulator.
- Generic iOS build with `CODE_SIGNING_ALLOWED=NO` succeeded.

Risks

- Low. The change removes dead iOS 8 compatibility paths and strengthens type checking for `CMAltimeter` calls.
- Real-device runtime behavior is expected to be unchanged because callback logic was left intact.

Device testing requirement

- Device testing is not required for this issue per #166.
- No device validation was performed.