### PR TITLE
Fix force_try in Utils.isValidBeaconUUID

### DIFF
--- a/ZIGSIMPlus/Utils.swift
+++ b/ZIGSIMPlus/Utils.swift
@@ -10,6 +10,10 @@ import Foundation
 import UIKit
 
 class Utils {
+    private static let beaconUUIDRegex = try? NSRegularExpression(
+        pattern: "[A-Z0-9]{8}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{12}"
+    )
+
     static func randomStringWithLength(_ length: Int) -> String {
         let alphabet = "-_1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
         return String((0 ..< length).map { _ -> Character in alphabet.randomElement()! })
@@ -88,8 +92,9 @@ class Utils {
     }
 
     static func isValidBeaconUUID(_ uuid: String) -> Bool {
-        // swiftlint:disable:next force_try
-        let reg = try! NSRegularExpression(pattern: "[A-Z0-9]{8}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{12}")
+        guard let reg = beaconUUIDRegex else {
+            return false
+        }
         return reg.matches(in: uuid, options: [], range: .init(location: 0, length: uuid.count)).count != 0
     }
 


### PR DESCRIPTION
Linked Issue
- Closes #167

Summary
- Replaces the per-call forced regex compilation in `Utils.isValidBeaconUUID` with a private static optional `NSRegularExpression` initialized using `try?`.
- Returns `false` if the static regex cannot be initialized.

Scope
- `ZIGSIMPlus/Utils.swift` only.

Non-goals
- No change to UUID validation rules.
- No change to `isValidBeaconUUID` matching semantics beyond avoiding `try!`.
- No signing, provisioning, entitlement, storyboard, xib, dependency, or architecture changes.

Changes
- Added `private static let beaconUUIDRegex`.
- Removed the `swiftlint:disable:next force_try` suppression.
- Reused the static regex inside `isValidBeaconUUID` with a `guard` fallback.

Validation commands
- `rg "try!|force_try|beaconUUIDRegex" ZIGSIMPlus/Utils.swift`
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -configuration Debug -destination generic/platform=iOS\\ Simulator build`
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -configuration Debug -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO build`

Results
- `rg` confirmed `Utils.swift` no longer contains `try!` or `force_try`, and does contain `beaconUUIDRegex`.
- Simulator build failed before final link because `Private/Prototypes/NDISwift/ofxNDI/libs/NDI/lib/ios/libndi_ios.a` is built for iOS, not iOS Simulator.
- Generic iOS build with `CODE_SIGNING_ALLOWED=NO` succeeded in the main checkout while this issue change was applied.
- A repeat generic iOS build in the isolated `/tmp/ZIGSIMPlus_issue167` worktree failed because that isolated worktree did not contain `Private/VideoCapture/CompositeRGBWithAlpha.metal`; the main checkout had the required private file.

Risks
- Low. The regex pattern and match-count behavior are unchanged.
- If the static regex initialization ever fails, validation now returns `false` instead of crashing.

Device testing requirement
- Device testing is not required for this issue.