### PR TITLE
Remove debug print statements across service and view files

### DIFF
--- a/ZIGSIMPlus/Models/FileWriter.swift
+++ b/ZIGSIMPlus/Models/FileWriter.swift
@@ -7,9 +7,15 @@
 //
 
 import Foundation
+import os.log
 
 class FileWriter {
     static let shared = FileWriter()
+    private static let log = OSLog(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.zigsim",
+        category: "FileWriter"
+    )
+
     private init() {}
 
     var output: OutputStream?
@@ -24,7 +30,12 @@ class FileWriter {
             stream.open()
             output = stream
         } else {
-            print("File I/O Error.")
+            os_log(
+                "File I/O error opening log file: %{public}@",
+                log: Self.log,
+                type: .error,
+                filepath
+            )
         }
     }
 
@@ -39,7 +50,13 @@ class FileWriter {
         }
 
         if bytesWritten != data.count {
-            print("Write failed")
+            os_log(
+                "File write failed. Expected %{public}d bytes, wrote %{public}d bytes.",
+                log: Self.log,
+                type: .error,
+                data.count,
+                bytesWritten ?? 0
+            )
         }
     }
 

--- a/ZIGSIMPlus/Models/Services/AltimeterService.swift
+++ b/ZIGSIMPlus/Models/Services/AltimeterService.swift
@@ -36,8 +36,6 @@ public class AltimeterService {
     }
 
     private func updateAltimeterData() {
-        print("pressure:pressure: \(pressureData)")
-        print("pressure:altitude: \(altitudeData)")
         var altimeterData = [0.0, 0.0]
         altimeterData[0] = pressureData
         altimeterData[1] = altitudeData

--- a/ZIGSIMPlus/Models/Services/LocationService.swift
+++ b/ZIGSIMPlus/Models/Services/LocationService.swift
@@ -134,11 +134,6 @@ extension LocationService: CLLocationManagerDelegate {
         compassData = newHeading.magneticHeading
     }
 
-    // Called when the device started monitoring
-    public func locationManager(_ manager: CLLocationManager, didStartMonitoringFor region: CLRegion) {
-        print("Start monitoring for iBeacon")
-    }
-
     // Called when new data is received from beacons
     public func locationManager(
         _ manager: CLLocationManager,

--- a/ZIGSIMPlus/Models/Services/RemoteControlService.swift
+++ b/ZIGSIMPlus/Models/Services/RemoteControlService.swift
@@ -8,12 +8,17 @@
 
 import Foundation
 import MediaPlayer
+import os.log
 import OSCKit
 import SwiftyJSON
 
 public class RemoteControlService: NSObject {
     // Singleton instance
     static let shared = RemoteControlService()
+    private static let log = OSLog(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.zigsim",
+        category: "RemoteControlService"
+    )
 
     // MARK: - Instance Properties
 
@@ -67,7 +72,12 @@ public class RemoteControlService: NSObject {
                 action: #selector(onTogglePlayPause(_:))
             )
         } catch {
-            print(">> yo Failed to start audio engine")
+            os_log(
+                "Failed to start audio engine: %{public}@",
+                log: Self.log,
+                type: .error,
+                String(describing: error)
+            )
         }
 
         // Add trigger for volumes

--- a/ZIGSIMPlus/Models/Services/ServiceManager.swift
+++ b/ZIGSIMPlus/Models/Services/ServiceManager.swift
@@ -8,6 +8,7 @@
 
 import DeviceKit
 import Foundation
+import os.log
 import OSCKit
 import SwiftyJSON
 
@@ -20,6 +21,11 @@ import SwiftyJSON
 /// - Add device data to it
 class ServiceManager {
     static let shared = ServiceManager()
+    private static let log = OSLog(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.zigsim",
+        category: "ServiceManager"
+    )
+
     private init() {}
 
     public func getData() -> Data {
@@ -113,7 +119,12 @@ class ServiceManager {
             try data.merge(with: VideoCaptureService.shared.toJSON())
             try data.merge(with: NFCService.shared.toJSON())
         } catch {
-            print(">> JSON convert error")
+            os_log(
+                "JSON convert error: %{public}@",
+                log: Self.log,
+                type: .error,
+                String(describing: error)
+            )
         }
 
         let device = Device.current

--- a/ZIGSIMPlus/Views/CommandSettingViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSettingViewController.swift
@@ -61,7 +61,6 @@ public class CommandSettingViewController: UIViewController {
     }
 
     public override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        print("touch screen!")
         if updateSettingTextData() {
             view.endEditing(true)
         }
@@ -72,7 +71,6 @@ public class CommandSettingViewController: UIViewController {
     }
 
     public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        print("should end editing!")
         if updateSettingTextData() {
             view.endEditing(true)
             return true


### PR DESCRIPTION
## Linked Issue

Closes #168

## Summary

Removed production debug `print` statements from service and view code. Error-path messages now use unified logging via `os_log` so useful failure context is retained without leaving debug prints in production paths.

## Scope

- Removed per-frame altimeter debug output.
- Removed touch/text-field debug output from the command settings view.
- Removed iBeacon monitoring start debug output.
- Replaced error-path prints in remote control audio startup, JSON conversion, and file writing with `os_log` error logs.

## Non-goals

- No logging infrastructure redesign.
- No error-handling behavior changes.
- No signing, provisioning, entitlement, permission, storyboard, or xib changes.

## Changes

- `AltimeterService`: deleted the two pressure/altitude `print` calls in the update path.
- `RemoteControlService`: added `os_log` error logging for audio engine start failures, including the caught error.
- `LocationService`: removed the debug-only iBeacon monitoring delegate print.
- `ServiceManager`: added `os_log` error logging for JSON merge failures, including the caught error.
- `CommandSettingViewController`: removed touch and return-key debug prints.
- `FileWriter`: added `os_log` error logging for file open/write failures.

## Validation Commands

- `rg -n "print\\(" ZIGSIMPlus/Models/Services/AltimeterService.swift ZIGSIMPlus/Models/Services/RemoteControlService.swift ZIGSIMPlus/Models/Services/LocationService.swift ZIGSIMPlus/Models/Services/ServiceManager.swift ZIGSIMPlus/Views/CommandSettingViewController.swift ZIGSIMPlus/Models/FileWriter.swift`
- `xcodebuild -list -workspace ZIGSIMPlus.xcworkspace`
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -destination 'generic/platform=iOS Simulator' build`
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -destination 'generic/platform=iOS' -derivedDataPath /tmp/ZIGSIMPlus-issue168-dd CODE_SIGNING_ALLOWED=NO build`

## Results

- `rg` found no remaining `print` calls in the six issue-scoped files.
- Workspace listing succeeded and confirmed the `ZIGSIMPlus` scheme.
- Simulator build failed at link time because `Private/Prototypes/NDISwift/ofxNDI/libs/NDI/lib/ios/libndi_ios.a` is built for iOS device, not iOS Simulator.
- Generic iOS device build with `CODE_SIGNING_ALLOWED=NO` succeeded.
- Build emitted existing warnings, including SwiftLint warnings and deprecation warnings, but no errors after the device build retry.

## Risks

Low. This change removes debug output and replaces only error-path messages with `os_log`; runtime control flow is unchanged.

## Device Testing Requirement

Device testing is not required for this issue. No device-only behavior was intentionally changed.