### PR TITLE
Fix ipAddress text field enum typo

### DIFF
--- a/ZIGSIMPlus/Presenters/CommandSettingPresenter.swift
+++ b/ZIGSIMPlus/Presenters/CommandSettingPresenter.swift
@@ -10,7 +10,7 @@ import Foundation
 import SwiftyUserDefaults
 
 public enum TextFieldName {
-    case ipAdress
+    case ipAddress
     case portNumber
     case uuid
 }
@@ -41,7 +41,7 @@ final class CommandSettingPresenter: CommandSettingPresenterProtocol {
     func getUserDefaultTexts() -> [TextFieldName: String] {
         var texts: [TextFieldName: String] = [:]
         let appSettings = AppSettingModel.shared
-        texts[.ipAdress] = appSettings.ipAddress
+        texts[.ipAddress] = appSettings.ipAddress
         texts[.portNumber] = appSettings.portNumber.description
         texts[.uuid] = appSettings.deviceUUID
         return texts
@@ -60,7 +60,7 @@ final class CommandSettingPresenter: CommandSettingPresenterProtocol {
 
     func updateTextsUserDefault(texts: [TextFieldName: String]) {
         let appSettings = AppSettingModel.shared
-        appSettings.ipAddress = texts[.ipAdress] ?? ""
+        appSettings.ipAddress = texts[.ipAddress] ?? ""
         appSettings.portNumber = Int(texts[.portNumber] ?? "0") ?? 0
         appSettings.deviceUUID = texts[.uuid] ?? ""
     }

--- a/ZIGSIMPlus/Views/CommandSettingViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSettingViewController.swift
@@ -30,7 +30,7 @@ public class CommandSettingViewController: UIViewController {
         let userDefaultTexts = presenter.getUserDefaultTexts()
         for textField in textFields {
             if textField.tag == 0 {
-                setTextFieldSetting(texField: textField, text: userDefaultTexts[.ipAdress]?.description ?? "")
+                setTextFieldSetting(texField: textField, text: userDefaultTexts[.ipAddress]?.description ?? "")
             } else if textField.tag == 1 {
                 setTextFieldSetting(texField: textField, text: userDefaultTexts[.portNumber]?.description ?? "")
             } else if textField.tag == 2 {
@@ -86,7 +86,7 @@ public class CommandSettingViewController: UIViewController {
         for textField in textFields {
             if textField.tag == 0 {
                 if Utils.isValidSettingViewText(text: textField, textType: .ipAddress), textField.text != "" {
-                    texts[.ipAdress] = textField.text ?? ""
+                    texts[.ipAddress] = textField.text ?? ""
                 } else {
                     return false
                 }


### PR DESCRIPTION
## Linked Issue

Closes #169

## Summary

Renames the misspelled `TextFieldName.ipAdress` case to `TextFieldName.ipAddress` and updates in-repo references.

## Scope

Limited to the `TextFieldName` case and direct call sites used by command setting text fields.

## Non-goals

- No `TextFieldName` design changes
- No other naming changes
- No storyboard, xib, signing, entitlement, permission, or dependency changes

## Changes

- Updated `CommandSettingPresenter.swift` enum case and dictionary references from `ipAdress` to `ipAddress`
- Updated `CommandSettingViewController.swift` references from `.ipAdress` to `.ipAddress`

## Validation commands

- `rg -n "ipAdress" ZIGSIMPlus`
- `xcodebuild -list -workspace ZIGSIMPlus.xcworkspace`
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -destination 'generic/platform=iOS Simulator' build`
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`

## Results

- `rg -n "ipAdress" ZIGSIMPlus` returned no matches
- Workspace schemes listed successfully
- Simulator build failed at link because `Private/Prototypes/NDISwift/ofxNDI/libs/NDI/lib/ios/libndi_ios.a` is built for iOS, not iOS simulator
- Generic iOS build with `CODE_SIGNING_ALLOWED=NO` succeeded
- Build emitted existing warnings, including SwiftLint warnings and script phase warnings unrelated to this rename

## Risks

Low. This is a public enum case rename, so external consumers still using `ipAdress` must update to `ipAddress`.

## Device testing requirement

Device testing is not required for this typo-only API/reference rename.