### PR TITLE
Issue #179: add DEBUG OSC byte dump logging

### DIFF
--- a/ZIGSIMPlus/Models/Services/ServiceManager.swift
+++ b/ZIGSIMPlus/Models/Services/ServiceManager.swift
@@ -8,6 +8,7 @@
 
 import DeviceKit
 import Foundation
+import os.log
 import OSCKit
 import SwiftyJSON
 
@@ -20,6 +21,10 @@ import SwiftyJSON
 /// - Add device data to it
 class ServiceManager {
     static let shared = ServiceManager()
+    private static let log = OSLog(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.zigsim",
+        category: "ServiceManager"
+    )
     private init() {}
 
     public func getData() -> Data {
@@ -28,6 +33,9 @@ class ServiceManager {
         if AppSettingModel.shared.transportFormat == .OSC {
             let osc = getOSC()
             data = (try? OSCPacket.bundle(osc).rawData()) ?? Data()
+            #if DEBUG
+                logOSCPacketBytes(data)
+            #endif
         } else {
             let json = getJSON()
             data = (try? json.rawData()) ?? Data()
@@ -141,4 +149,20 @@ class ServiceManager {
 
         return log.count == 0 ? nil : log.joined(separator: "\n")
     }
+
+    #if DEBUG
+        private func logOSCPacketBytes(_ data: Data) {
+            let hexDump = data.prefix(64)
+                .map { String(format: "%02x", $0) }
+                .joined(separator: " ")
+
+            os_log(
+                "OSC bundle bytes: size=%{public}d first64=%{public}@",
+                log: Self.log,
+                type: .debug,
+                data.count,
+                hexDump
+            )
+        }
+    #endif
 }

--- a/ZIGSIMPlus/Models/Services/ServiceManager.swift
+++ b/ZIGSIMPlus/Models/Services/ServiceManager.swift
@@ -152,17 +152,30 @@ class ServiceManager {
 
     #if DEBUG
         private func logOSCPacketBytes(_ data: Data) {
-            let hexDump = data.prefix(64)
-                .map { String(format: "%02x", $0) }
-                .joined(separator: " ")
-
             os_log(
-                "OSC bundle bytes: size=%{public}d first64=%{public}@",
+                "OSC bundle bytes: size=%{public}d",
                 log: Self.log,
                 type: .debug,
-                data.count,
-                hexDump
+                data.count
             )
+
+            for offset in stride(from: 0, to: data.count, by: 16) {
+                let lineBytes = data[offset..<min(offset + 16, data.count)]
+                let hexDump = lineBytes.enumerated()
+                    .map { index, byte in
+                        index == 8
+                            ? " " + String(format: "%02x", byte)
+                            : String(format: "%02x", byte)
+                    }
+                    .joined(separator: " ")
+
+                os_log(
+                    "[OSCBundle] %{public}@",
+                    log: Self.log,
+                    type: .debug,
+                    String(format: "%08x: %@", offset, hexDump)
+                )
+            }
         }
     #endif
 }


### PR DESCRIPTION
Linked Issue
- Closes #179

Summary
- Add a DEBUG-only OSC packet byte log immediately after `ServiceManager.getData()` generates OSC data.
- Log the total byte count and a hex dump of the first 64 bytes.

Scope
- `ZIGSIMPlus/Models/Services/ServiceManager.swift`
- DEBUG-only logging for OSC payload generation

Non-goals
- No changes to OSC bundle structure
- No changes to network transmission logic
- No uOSC-side changes

Changes
- Added an `OSLog` instance for `ServiceManager`
- Logged generated OSC bundle data behind `#if DEBUG`
- Formatted the log output as `size=<count>` plus the first 64 bytes in hex

Validation steps
- `xcodebuild -list -workspace ZIGSIMPlus.xcworkspace`
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`

Results
- `xcodebuild -list` succeeded and confirmed the `ZIGSIMPlus` scheme in `ZIGSIMPlus.xcworkspace`
- Debug simulator build reached the final app link step, then failed due to an existing NDI static library mismatch: `libndi_ios.a` is built for iOS device, not iOS Simulator
- No build error was reported from `ServiceManager.swift` before that link failure

Risks
- Low risk; the runtime send path is unchanged and the new log is compiled only in DEBUG builds
- Manual runtime confirmation of the emitted byte dump is still needed in a DEBUG run

Device test requirements
- Device testing was not performed
- This issue is logging-only and the issue description marks device testing as not required
