### PR TITLE
Issue #181: Fix OSC float tags for Unity/uOSC compatibility

### DIFF
--- a/ZIGSIMPlus/Models/Services/AltimeterService.swift
+++ b/ZIGSIMPlus/Models/Services/AltimeterService.swift
@@ -96,7 +96,7 @@ extension AltimeterService: Service {
         var messages = [OSCMessage]()
 
         if AppSettingModel.shared.isActiveByCommand[Command.pressure] ?? false {
-            messages.append(osc("pressure", pressureData, altitudeData))
+            messages.append(osc("pressure", Float(pressureData), Float(altitudeData)))
         }
 
         return messages

--- a/ZIGSIMPlus/Models/Services/LocationService.swift
+++ b/ZIGSIMPlus/Models/Services/LocationService.swift
@@ -199,11 +199,11 @@ extension LocationService: Service {
         var data = [OSCMessage]()
 
         if AppSettingModel.shared.isActiveByCommand[Command.gps] ?? false {
-            data.append(osc("gps", latitudeData, longitudeData))
+            data.append(osc("gps", Float(latitudeData), Float(longitudeData)))
         }
 
         if AppSettingModel.shared.isActiveByCommand[Command.compass] ?? false {
-            data.append(osc("compass", compassData, AppSettingModel.shared.compassOrientation.rawValue))
+            data.append(osc("compass", Float(compassData), AppSettingModel.shared.compassOrientation.rawValue))
         }
 
         if AppSettingModel.shared.isActiveByCommand[Command.beacon] ?? false {

--- a/ZIGSIMPlus/Models/Services/MotionService.swift
+++ b/ZIGSIMPlus/Models/Services/MotionService.swift
@@ -112,19 +112,21 @@ extension MotionService: Service {
         var messages = [OSCMessage]()
 
         if AppSettingModel.shared.isActiveByCommand[Command.acceleration] ?? false {
-            messages.append(osc("accel", accel.x, accel.y, accel.z))
+            messages.append(osc("accel", Float(accel.x), Float(accel.y), Float(accel.z)))
         }
 
         if AppSettingModel.shared.isActiveByCommand[Command.gravity] ?? false {
-            messages.append(osc("gravity", gravity.x, gravity.y, gravity.z))
+            messages.append(osc("gravity", Float(gravity.x), Float(gravity.y), Float(gravity.z)))
         }
 
         if AppSettingModel.shared.isActiveByCommand[Command.gyro] ?? false {
-            messages.append(osc("gyro", gyro.x, gyro.y, gyro.z))
+            messages.append(osc("gyro", Float(gyro.x), Float(gyro.y), Float(gyro.z)))
         }
 
         if AppSettingModel.shared.isActiveByCommand[Command.quaternion] ?? false {
-            messages.append(osc("quaternion", quaternion.x, quaternion.y, quaternion.z, quaternion.w))
+            messages.append(
+                osc("quaternion", Float(quaternion.x), Float(quaternion.y), Float(quaternion.z), Float(quaternion.w))
+            )
         }
 
         return messages


### PR DESCRIPTION
## Linked Issue
- Closes #181

## Summary
- Cast OSC payload values to `Float` before building OSC messages so OSCKit emits `f` tags instead of `d`
- Fix the confirmed Unity `uOSC` parsing failure caused by unsupported float64 payloads shifting bundle parsing offsets

## Scope
- `MotionService.toOSC()` for `accel`, `gravity`, `gyro`, and `quaternion`
- Other `toOSC()` paths still emitting `Double` payloads: `AltimeterService` and `LocationService`

## Non-goals
- No changes to Unity/uOSC
- No changes to JSON output paths
- No changes to ARKitService or other services already using float32 OSC payloads
- No architecture or dependency changes

## Changes
- Converted `MotionService` OSC arguments from CoreMotion `Double` values to `Float`
- Converted `AltimeterService` OSC pressure/altitude payloads to `Float`
- Converted `LocationService` OSC GPS and compass payloads to `Float`
- Left logs and JSON serialization unchanged

## Validation Commands
- `rg -n "osc\(" ZIGSIMPlus/Models/Services/*.swift`
- `git diff --check -- ZIGSIMPlus/Models/Services/MotionService.swift ZIGSIMPlus/Models/Services/AltimeterService.swift ZIGSIMPlus/Models/Services/LocationService.swift`
- `xcodebuild -list -workspace ZIGSIMPlus.xcworkspace`
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -destination 'generic/platform=iOS Simulator' build`

## Results
- Confirmed the targeted OSC serialization sites now cast issue-relevant numeric payloads to `Float`
- Confirmed no formatting issues in the edited files
- Simulator build did not complete because of a pre-existing linker issue outside this change:
  `ld: building for 'iOS-simulator', but linking in object file .../libndi_ios.a ... built for 'iOS'`
- Real Unity/uOSC validation was not run in this environment

## Risks
- OSC transport precision is reduced from float64 to float32 for the affected payloads
- Full app simulator build remains blocked by the existing NDI static library linkage issue, so this PR relies on targeted code inspection plus partial compilation through the edited files

## Device Test Requirements
- `needs-device-test`
- Required: validate on a real iPhone connected to a Unity `uOSC` receiver while moving the device and confirm the previous bundle parse error no longer appears
- Also verify other OSC receivers still accept the float32 payloads
