### PR TITLE
Issue #176: Replace CommandAndServiceMediator switches with command delegation

### DIFF
--- a/ZIGSIMPlus/Entities/Command.swift
+++ b/ZIGSIMPlus/Entities/Command.swift
@@ -53,4 +53,101 @@ public enum Command: String, CaseIterable {
         case .battery: return DefaultsKeys.isBatteryCommandActive
         }
     }
+
+    func isAvailable() -> Bool {
+        switch self {
+        case .acceleration, .gravity, .gyro, .quaternion:
+            return MotionService.shared.isAvailable()
+        case .touch:
+            return TouchService.shared.isTouchAvailable()
+        case .applePencil:
+            return TouchService.shared.isApplePencilAvailable()
+        case .battery:
+            return BatteryService.shared.isAvailable()
+        case .compass, .gps, .beacon:
+            return LocationService.shared.isLocationAvailable()
+        case .pressure:
+            return AltimeterService.shared.isAvailable()
+        case .proximity:
+            return ProximityService.shared.isAvailable()
+        case .micLevel:
+            return AudioLevelService.shared.isAvailable()
+        case .arkit:
+            return isCameraAvailable() && ArkitService.shared.isARKitAvailable()
+        case .remoteControl:
+            return RemoteControlService.shared.isAvailable()
+        case .ndi:
+            return isCameraAvailable() && VideoCaptureService.shared.isNDIAvailable()
+        case .imageDetection:
+            return isCameraAvailable() && VideoCaptureService.shared.isImageDetectionAvailable()
+        case .nfc:
+            return NFCService.shared.isAvailable()
+        }
+    }
+
+    func start() {
+        switch self {
+        case .acceleration, .gravity, .gyro, .quaternion:
+            MotionService.shared.start()
+        case .touch, .applePencil:
+            TouchService.shared.enable()
+        case .battery:
+            BatteryService.shared.startBattery()
+        case .compass:
+            LocationService.shared.startCompass()
+        case .gps:
+            LocationService.shared.startGps()
+        case .beacon:
+            LocationService.shared.startBeacons()
+        case .pressure:
+            AltimeterService.shared.startAltimeter()
+        case .proximity:
+            ProximityService.shared.start()
+        case .micLevel:
+            AudioLevelService.shared.start()
+        case .arkit:
+            ArkitService.shared.start()
+        case .remoteControl:
+            RemoteControlService.shared.start()
+        case .ndi, .imageDetection:
+            VideoCaptureService.shared.start()
+        case .nfc:
+            NFCService.shared.start()
+        }
+    }
+
+    func stop() {
+        switch self {
+        case .acceleration, .gravity, .gyro, .quaternion:
+            MotionService.shared.stop()
+        case .touch, .applePencil:
+            TouchService.shared.disable()
+        case .battery:
+            BatteryService.shared.stopBattery()
+        case .compass:
+            LocationService.shared.stopCompass()
+        case .gps:
+            LocationService.shared.stopGps()
+        case .beacon:
+            LocationService.shared.stopBeacons()
+        case .pressure:
+            AltimeterService.shared.stopAltimeter()
+        case .proximity:
+            ProximityService.shared.stop()
+        case .micLevel:
+            AudioLevelService.shared.stop()
+        case .arkit:
+            ArkitService.shared.stop()
+        case .remoteControl:
+            RemoteControlService.shared.stop()
+        case .ndi, .imageDetection:
+            VideoCaptureService.shared.stop()
+        case .nfc:
+            NFCService.shared.stop()
+        }
+    }
+
+    private func isCameraAvailable() -> Bool {
+        !AppSettingModel.shared.isCameraUsed(exceptBy: self)
+    }
 }

--- a/ZIGSIMPlus/Models/CommandAndServiceMediator.swift
+++ b/ZIGSIMPlus/Models/CommandAndServiceMediator.swift
@@ -14,118 +14,15 @@ public class CommandAndServiceMediator {
     /// Returns if the service for given command is available.
     ///
     /// Simultaneous use of multiple commands accessing camera is not allowed.
-    public static func isAvailable(_ command: Command) -> Bool { // swiftlint:disable:this cyclomatic_complexity
-        switch command {
-        case .acceleration, .gravity, .gyro, .quaternion:
-            return MotionService.shared.isAvailable()
-        case .touch:
-            return TouchService.shared.isTouchAvailable()
-        case .applePencil:
-            return TouchService.shared.isApplePencilAvailable()
-        case .battery:
-            return BatteryService.shared.isAvailable()
-        case .compass, .gps, .beacon:
-            return LocationService.shared.isLocationAvailable()
-        case .pressure:
-            return AltimeterService.shared.isAvailable()
-        case .proximity:
-            return ProximityService.shared.isAvailable()
-        case .micLevel:
-            return AudioLevelService.shared.isAvailable()
-        case .arkit:
-            if isCameraAvailable(for: .arkit) {
-                return ArkitService.shared.isARKitAvailable()
-            } else {
-                return false
-            }
-        case .remoteControl:
-            return RemoteControlService.shared.isAvailable()
-        case .ndi:
-            if isCameraAvailable(for: .ndi) {
-                return VideoCaptureService.shared.isNDIAvailable()
-            } else {
-                return false
-            }
-        case .imageDetection:
-            if isCameraAvailable(for: .imageDetection) {
-                return VideoCaptureService.shared.isImageDetectionAvailable()
-            } else {
-                return false
-            }
-        case .nfc:
-            return NFCService.shared.isAvailable()
-        }
+    public static func isAvailable(_ command: Command) -> Bool {
+        command.isAvailable()
     }
 
-    // swiftlint:disable:next cyclomatic_complexity
     public static func startCommand(_ command: Command) {
-        switch command {
-        case .acceleration, .gravity, .gyro, .quaternion:
-            MotionService.shared.start()
-        case .touch, .applePencil:
-            TouchService.shared.enable()
-        case .battery:
-            BatteryService.shared.startBattery()
-        case .compass:
-            LocationService.shared.startCompass()
-        case .gps:
-            LocationService.shared.startGps()
-        case .beacon:
-            LocationService.shared.startBeacons()
-        case .pressure:
-            AltimeterService.shared.startAltimeter()
-        case .proximity:
-            ProximityService.shared.start()
-        case .micLevel:
-            AudioLevelService.shared.start()
-        case .arkit:
-            ArkitService.shared.start()
-        case .remoteControl:
-            RemoteControlService.shared.start()
-        case .ndi, .imageDetection:
-            VideoCaptureService.shared.start()
-        case .nfc:
-            NFCService.shared.start()
-        }
+        command.start()
     }
 
-    // swiftlint:disable:next cyclomatic_complexity
     public static func stopCommand(_ command: Command) {
-        switch command {
-        case .acceleration, .gravity, .gyro, .quaternion:
-            MotionService.shared.stop()
-        case .touch, .applePencil:
-            TouchService.shared.disable()
-        case .battery:
-            BatteryService.shared.stopBattery()
-        case .compass:
-            LocationService.shared.stopCompass()
-        case .gps:
-            LocationService.shared.stopGps()
-        case .beacon:
-            LocationService.shared.stopBeacons()
-        case .pressure:
-            AltimeterService.shared.stopAltimeter()
-        case .proximity:
-            ProximityService.shared.stop()
-        case .micLevel:
-            AudioLevelService.shared.stop()
-        case .arkit:
-            ArkitService.shared.stop()
-        case .remoteControl:
-            RemoteControlService.shared.stop()
-        case .ndi, .imageDetection:
-            VideoCaptureService.shared.stop()
-        case .nfc:
-            NFCService.shared.stop()
-        }
-    }
-
-    // MARK: - Private methods
-
-    private static func isCameraAvailable(for command: Command) -> Bool {
-        // When camera is set to on by other command,
-        // user cannot use camera
-        return !AppSettingModel.shared.isCameraUsed(exceptBy: command)
+        command.stop()
     }
 }


### PR DESCRIPTION
# Summary

- Move command-specific service availability/start/stop behavior onto `Command`
- Keep `CommandAndServiceMediator` public methods intact while delegating to `Command`

---

# Related Issue

Closes #176

---

# Scope

## In Scope

- Add `isAvailable()`, `start()`, and `stop()` behavior to `Command`
- Preserve the existing camera exclusivity rule for `arkit`, `ndi`, and `imageDetection`
- Remove the `switch` accumulation and `cyclomatic_complexity` suppressions from `CommandAndServiceMediator`

## Out of Scope (Non-goals)

- Changing any `Service` class internals
- Adding or removing `Command` cases
- Changing callers such as `CommandPlayer`

---

# Changes

- Added command-side delegation methods in `ZIGSIMPlus/Entities/Command.swift`
- Moved the camera availability guard to a private `Command` helper using `AppSettingModel.shared.isCameraUsed(exceptBy:)`
- Replaced the mediator's three `switch` statements with direct delegation and removed the lint suppression comments

---

# Validation

## Commands Run

- `xcodebuild -list -workspace ZIGSIMPlus.xcworkspace`
- `xcodebuild build -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -destination 'generic/platform=iOS'`

## Results

- Workspace resolved successfully and exposed the `ZIGSIMPlus` scheme
- `xcodebuild build` succeeded
- Existing SwiftLint warnings were reported in unrelated files; no new build failures were introduced by this change

---

# Device Testing

- Status: Not required
- Notes: Issue scope is logic relocation only. No UI or device-specific runtime behavior was intentionally changed.

---

# Risks / Concerns

- Service mapping still lives in `Command`, so adding a new command still requires updating the enum-side delegation there
- The three command methods in `Command` still use `switch`, so complexity moved out of the mediator but was not abstracted into a separate protocol-backed service type
- Camera-gated commands rely on the existing `AppSettingModel.shared.isCameraUsed(exceptBy:)` behavior remaining unchanged

---

# Additional Notes

- Branch was created from `modernize`
- PR targets `modernize`
- Real-device validation was not performed

# Checklist

- [x] Branch is created from `modernize`
- [x] PR targets `modernize`
- [x] Scope matches Issue
- [x] No unrelated changes included
- [x] Validation commands were executed
- [x] Risks are documented
- [x] Device testing requirement is stated