### PR TITLE
Issue #190 CommandDetailSettingsPresenter の enum 初期化を安全化

### DIFF
--- a/ZIGSIMPlus/Presenters/CommandDetailSettingsPresenter.swift
+++ b/ZIGSIMPlus/Presenters/CommandDetailSettingsPresenter.swift
@@ -149,37 +149,37 @@ final class CommandDetailSettingsPresenter: CommandDetailSettingsPresenterProtoc
         case let data as SegmentedInt:
             switch data.key {
             case .ndiSceneType:
-                AppSettingModel.shared.ndiSceneType = NdiSceneType(rawValue: data.value)!
+                AppSettingModel.shared.ndiSceneType = NdiSceneType(rawValue: data.value) ?? .WORLD
             case .ndiWorldType:
-                AppSettingModel.shared.ndiWorldType = NdiWorldType(rawValue: data.value)!
+                AppSettingModel.shared.ndiWorldType = NdiWorldType(rawValue: data.value) ?? .CAMERA
             case .ndiCamera:
-                AppSettingModel.shared.ndiCameraPosition = CameraPosition(rawValue: data.value)!
+                AppSettingModel.shared.ndiCameraPosition = CameraPosition(rawValue: data.value) ?? .BACK
             case .ndiDepthType:
-                AppSettingModel.shared.depthType = DepthType(rawValue: data.value)!
+                AppSettingModel.shared.depthType = DepthType(rawValue: data.value) ?? .DEPTH
             case .ndiHumanType:
-                AppSettingModel.shared.ndiHumanType = NdiHumanType(rawValue: data.value)!
+                AppSettingModel.shared.ndiHumanType = NdiHumanType(rawValue: data.value) ?? .HUMAN
             case .ndiResolution:
-                AppSettingModel.shared.ndiResolution = VideoResolution(rawValue: data.value)!
+                AppSettingModel.shared.ndiResolution = VideoResolution(rawValue: data.value) ?? .vga
             case .ndiAudioBufferSize:
-                AppSettingModel.shared.ndiAudioBufferSize = NdiAudioBufferSize(rawValue: data.value)!
+                AppSettingModel.shared.ndiAudioBufferSize = NdiAudioBufferSize(rawValue: data.value) ?? .large
             case .ndiAudioEnabled:
-                AppSettingModel.shared.ndiAudioEnabled = NdiAudioEnabled(rawValue: data.value)!
+                AppSettingModel.shared.ndiAudioEnabled = NdiAudioEnabled(rawValue: data.value) ?? .enabled
             case .compassOrientation:
-                AppSettingModel.shared.compassOrientation = CompassOrientation(rawValue: data.value)!
+                AppSettingModel.shared.compassOrientation = CompassOrientation(rawValue: data.value) ?? .portrait
             case .arkitTrackingType:
-                AppSettingModel.shared.arkitTrackingType = ArkitTrackingType(rawValue: data.value)!
+                AppSettingModel.shared.arkitTrackingType = ArkitTrackingType(rawValue: data.value) ?? .device
             case .arkitFeaturePointsEnabled:
-                AppSettingModel.shared.arkitFeaturePointsEnabled = ArkitFeaturePointsEnabled(rawValue: data.value)!
+                AppSettingModel.shared.arkitFeaturePointsEnabled = ArkitFeaturePointsEnabled(rawValue: data.value) ?? .enabled
             case .imageDetectorType:
-                AppSettingModel.shared.imageDetectorType = ImageDetectorType(rawValue: data.value)!
+                AppSettingModel.shared.imageDetectorType = ImageDetectorType(rawValue: data.value) ?? .face
             case .imageDetectorCameraPosition:
-                AppSettingModel.shared.imageDetectorCameraPosition = CameraPosition(rawValue: data.value)!
+                AppSettingModel.shared.imageDetectorCameraPosition = CameraPosition(rawValue: data.value) ?? .BACK
             case .imageDetectorResolution:
-                AppSettingModel.shared.imageDetectorResolution = VideoResolution(rawValue: data.value)!
+                AppSettingModel.shared.imageDetectorResolution = VideoResolution(rawValue: data.value) ?? .vga
             case .imageDetectorAccuracy:
-                AppSettingModel.shared.imageDetectorAccuracy = ImageDetectorAccuracy(rawValue: data.value)!
+                AppSettingModel.shared.imageDetectorAccuracy = ImageDetectorAccuracy(rawValue: data.value) ?? .high
             case .imageDetectorNumberOfAngles:
-                AppSettingModel.shared.imageDetectorNumberOfAngles = ImageDetectorNumberOfAngles(rawValue: data.value)!
+                AppSettingModel.shared.imageDetectorNumberOfAngles = ImageDetectorNumberOfAngles(rawValue: data.value) ?? .one
             default:
                 fatalError("Undefined key")
             }


### PR DESCRIPTION
## Linked Issue
- Closes #190

## Summary
- `CommandDetailSettingsPresenter.updateSetting` 内の enum `rawValue` 初期化で使われていた force unwrap を安全なフォールバック付きの初期化に置き換えました。
- `UISegmentedControl` の `selectedSegmentIndex` が想定外の値でもクラッシュしないようにしています。

## Scope
- `ZIGSIMPlus/Presenters/CommandDetailSettingsPresenter.swift` の対象箇所にある `Xxx(rawValue: data.value)!` を `?? defaultValue` に変更
- 現在の `modernize` 上の対象ブロックには 16 箇所の force unwrap が存在していたため、その全てを置換
- 各デフォルト値は `AppSettingModel` の既定値に合わせています

## Non-goals
- `updateSetting` メソッドの設計変更
- `DetailSetting` プロトコルの変更
- 対象箇所以外のリファクタリング

## Changes
- `NdiSceneType` を `?? .WORLD` に変更
- `NdiWorldType` を `?? .CAMERA` に変更
- `CameraPosition` を `?? .BACK` に変更
- `DepthType` を `?? .DEPTH` に変更
- `NdiHumanType` を `?? .HUMAN` に変更
- `VideoResolution` を `?? .vga` に変更
- `NdiAudioBufferSize` を `?? .large` に変更
- `NdiAudioEnabled` を `?? .enabled` に変更
- `CompassOrientation` を `?? .portrait` に変更
- `ArkitTrackingType` を `?? .device` に変更
- `ArkitFeaturePointsEnabled` を `?? .enabled` に変更
- `ImageDetectorType` を `?? .face` に変更
- `ImageDetectorAccuracy` を `?? .high` に変更
- `ImageDetectorNumberOfAngles` を `?? .one` に変更

## Validation commands
- `xcodebuild -project /tmp/ZIGSIMPlus_issue190/ZIGSIMPlus.xcodeproj -target ZIGSIMPlus -configuration Debug -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build`
- `git -C /tmp/ZIGSIMPlus_issue190 diff --check`

## Results
- `git diff --check`: 成功
- `xcodebuild ... build`: 失敗
- 失敗内容: Swift Package 解決中に `SourceKitten` パッケージで `Source files for target sourcekitten should be located under 'Sources/sourcekitten'` が発生し、ビルド完了まで到達できませんでした
- テスト: 専用テストは未実行です
- lint: 専用 lint コマンドは未実行です

## Risks
- 実装リスクは low です
- ビルド未完了のため、受け入れ条件の「ビルド成功」は現時点で未達です
- 失敗は依存パッケージ解決段階で発生しており、今回の presenter 修正と直接は無関係に見えます

## Device testing requirement
- この変更は enum 変換時の安全化のみのため、Issue 記載どおり実機テストは不要です