### PR TITLE
CommandOutputPresenter の force cast を安全なキャストに修正

### DIFF
--- a/ZIGSIMPlus/Presenters/CommandOutputPresenter.swift
+++ b/ZIGSIMPlus/Presenters/CommandOutputPresenter.swift
@@ -38,8 +38,11 @@ final class CommandOutputPresenter: CommandOutputPresenterProtocol {
     // https://stackoverflow.com/questions/50780404/swift-how-to-reference-subview-from-appdelegate
     func composeChildViewArchitecture() {
         let factory = PresenterFactory()
-        // swiftlint:disable:next force_cast
-        factory.createVideoCapturePresenter(parentView: view as! CommandOutputViewController)
+        guard let commandOutputViewController = view as? CommandOutputViewController else {
+            NSLog("CommandOutputPresenter expected CommandOutputViewController for composeChildViewArchitecture.")
+            return
+        }
+        factory.createVideoCapturePresenter(parentView: commandOutputViewController)
     }
 
     func startCommands() {


### PR DESCRIPTION
# Summary

- `CommandOutputPresenter` の `view as! CommandOutputViewController` を安全なキャストに置き換えました。

---

# Related Issue

Closes #189

---

# Scope

## In Scope

- `CommandOutputPresenter.composeChildViewArchitecture()` 内の force cast 修正
- キャスト失敗時のログ出力と早期 return の追加

## Out of Scope (Non-goals)

- Presenter と View の設計変更
- `CommandOutputPresenterDelegate` プロトコルの変更
- そのほかの force unwrap / force cast の修正

---

# Changes

- `view as! CommandOutputViewController` を `as?` + `guard let` に変更
- キャスト失敗時に `NSLog` を出力して処理を中断するように変更
- 既存の child presenter 生成フローは、キャスト成功時のみ維持

---

# Validation

## Commands Run

- `xcodebuild -project ZIGSIMPlus.xcodeproj -scheme ZIGSIMPlus -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/ZIGSIMPlus-issue189-derived-run2 CODE_SIGNING_ALLOWED=NO build`

## Results

- 上記コマンドは実行済みです。
- この PR 作成時点では SPM 依存関係と SwiftLint プラグインのビルド処理が長時間継続しており、最終的な build success はまだ確認できていません。
- したがって、ローカルビルド成功は未確認です。

---

# Device Testing

- Status: Not required
- Notes: Presenter 内の安全なキャスト修正のみで、実機依存の挙動変更は想定していません。

---

# Risks / Concerns

- `CommandOutputPresenterDelegate` を `CommandOutputViewController` 以外で使うケースでは、child presenter の生成はスキップされます。
- これはクラッシュ回避のための意図したフォールバックですが、既存で暗黙に force cast 前提だった経路がある場合はログ確認が必要です。
- ローカルビルド成功は未確認のため、レビュー時に再実行が必要です。

---

# Additional Notes

- 実装は `ZIGSIMPlus/Presenters/CommandOutputPresenter.swift` のみを変更しています。
- 実機テストは未実施です。

# Checklist

- [x] Branch is created from `modernize`
- [x] PR targets `modernize`
- [x] Scope matches Issue
- [x] No unrelated changes included
- [x] Validation commands were executed
- [x] Risks are documented
- [x] Device testing requirement is stated