### PR TITLE
Issue #191 利用規約 plist 読み込みの強制アンラップを解消

### DIFF
--- a/ZIGSIMPlus/Views/TermsOfUseViewController.swift
+++ b/ZIGSIMPlus/Views/TermsOfUseViewController.swift
@@ -14,8 +14,18 @@ public class TermsOfUseViewController: UIViewController {
     @IBOutlet var text: UITextView!
     public override func viewDidLoad() {
         super.viewDidLoad()
-        let filePath = Bundle.main.path(forResource: "TermsOfUse", ofType: "plist")
-        let plist = NSDictionary(contentsOfFile: filePath!)
+        guard let filePath = Bundle.main.path(forResource: "TermsOfUse", ofType: "plist") else {
+            NSLog("TermsOfUse.plist was not found in the main bundle.")
+            DispatchQueue.main.async { [weak self] in
+                if let navigationController = self?.navigationController {
+                    navigationController.popViewController(animated: true)
+                } else {
+                    self?.dismiss(animated: true)
+                }
+            }
+            return
+        }
+        let plist = NSDictionary(contentsOfFile: filePath)
         let termsOfuse: String? = plist?["TermsOfUse"] as? String
         let markdownParser = MarkdownParser(font: UIFont.systemFont(ofSize: 10))
         markdownParser.bold.font = UIFont.systemFont(ofSize: 24)


### PR DESCRIPTION
## Linked Issue
- #191

## Summary
- `TermsOfUseViewController` で `TermsOfUse.plist` のパス取得に使っていた強制アンラップを `guard let` に置き換えました。
- plist が見つからない場合でもクラッシュせず、ログを出したうえで画面を閉じるフォールバックを追加しました。

## Scope
- `ZIGSIMPlus/Views/TermsOfUseViewController.swift` のみ
- `Bundle.main.path(forResource:ofType:)` の安全化
- plist 未検出時の最小限のフォールバック追加

## Non-goals
- 利用規約表示ロジック自体の変更
- `TermsOfUse.plist` の内容や構造の変更
- その他画面や設定のリファクタ

## Changes
- `guard let filePath = ...` に変更し、`filePath!` を除去
- plist 未検出時に `NSLog` を出力
- 遷移形態に応じて `popViewController` または `dismiss` を実行して空画面を避けるよう変更
- `NSDictionary(contentsOfFile:)` 呼び出しを安全化

## Validation Commands
- `xcodebuild -project ZIGSIMPlus.xcodeproj -target ZIGSIMPlus -configuration Debug -sdk iphonesimulator build`
- `xcodebuild -project ZIGSIMPlus.xcodeproj -scheme ZIGSIMPlus -configuration Debug -sdk iphonesimulator -derivedDataPath /tmp/zigsimplus_issue191_dd build`

## Results
- 1つ目のコマンド: 既存の SwiftLint パッケージキャッシュ衝突で失敗
- 2つ目のコマンド: アプリ本体のコンパイルまでは進みましたが、最終リンクで既存の NDI 静的ライブラリが simulator 非対応のため失敗
- 失敗内容: `libndi_ios.a` が `iOS-simulator` ではなく `iOS` 向けにビルドされており、今回の差分起因のエラーではありません

## Risks
- plist 未検出時のフォールバックは画面を閉じる挙動です。呼び出し元が modal でも navigation push でも動作するよう分岐していますが、UX としてはログ出力付きのクローズを選択しています。
- ビルドは既存のリンク問題により最終成功までは確認できていません。

## Device Testing Requirement
- 不要