### PR TITLE
Issue #187 AudioLevelService の queue・timer 強制アンラップをオプショナル型に修正

### DIFF
--- a/ZIGSIMPlus/Models/Services/AudioLevelService.swift
+++ b/ZIGSIMPlus/Models/Services/AudioLevelService.swift
@@ -25,8 +25,8 @@ class AudioLevelService {
 
     // MARK: - Instance Properties
 
-    var queue: AudioQueueRef!
-    var timer: Timer!
+    var queue: AudioQueueRef?
+    var timer: Timer?
     var dataFormat = AudioStreamBasicDescription(
         mSampleRate: 44100.0,
         mFormatID: kAudioFormatLinearPCM,
@@ -45,6 +45,10 @@ class AudioLevelService {
     var callbackAudio: (([Float]) -> Void)?
 
     @objc func detectVolume(timer: Timer) {
+        guard let queue else {
+            return
+        }
+
         // Get level
         var levelMeter = AudioQueueLevelMeterState()
         var propertySize = UInt32(MemoryLayout<AudioQueueLevelMeterState>.size)
@@ -99,7 +103,15 @@ class AudioLevelService {
 
         if error == noErr {
             queue = audioQueue
+        } else {
+            queue = nil
+            return
         }
+
+        guard let queue else {
+            return
+        }
+
         AudioQueueStart(queue, nil)
 
         // Enable level meter
@@ -122,11 +134,17 @@ class AudioLevelService {
 
     public func stop() {
         // Finish observation
-        timer.invalidate()
+        timer?.invalidate()
         timer = nil
+
+        guard let queue else {
+            return
+        }
+
         AudioQueueFlush(queue)
         AudioQueueStop(queue, false)
         AudioQueueDispose(queue, true)
+        self.queue = nil
     }
 }
 


### PR DESCRIPTION
## Linked Issue
- Closes #187

## Summary
- `AudioLevelService` の `queue` と `timer` の強制アンラップをオプショナル型に変更し、初期化失敗時や `stop()` の先行呼び出し時のクラッシュ経路を防止しました。

## Scope
- `ZIGSIMPlus/Models/Services/AudioLevelService.swift`
- `start()` 内の `AudioQueueNewInput` 成功確認後のみ `AudioQueueStart` を実行
- `stop()` と音量検出時の `queue` / `timer` の nil 安全化

## Non-goals
- オーディオ処理ロジック自体の変更
- `unsafeBitCast` パターンの置き換え
- AVAudioEngine への移行
- 他ファイルの SwiftLint 警告や依存関係問題の解消

## Changes
- `queue` を `AudioQueueRef?` に変更
- `timer` を `Timer?` に変更
- `start()` で `AudioQueueNewInput` 失敗時は早期 return し、`AudioQueueStart` を呼ばないよう修正
- `detectVolume(timer:)` と `stop()` で `guard let queue` / `timer?` を使い nil 安全化
- `stop()` 完了後に `queue` を `nil` に戻すよう修正

## Validation Steps
- `git -C /tmp/ZIGSIMPlus_iOS_Public_issue_187 diff --check`
- `xcodebuild -project /tmp/ZIGSIMPlus_iOS_Public_issue_187/ZIGSIMPlus.xcodeproj -target ZIGSIMPlus -configuration Debug -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO -onlyUsePackageVersionsFromResolvedFile -disableAutomaticPackageResolution build`

## Results
- `diff --check`: 成功
- `xcodebuild`: 失敗
- 失敗内容: 依存パッケージ `OSCKitCore` のビルドで `SwiftASCII` / `SwiftDataParsing` の module dependency を解決できず失敗
- 補足: issue の変更対象ファイル `AudioLevelService.swift` 由来のコンパイルエラーは確認されていません

## Risks
- 実機でのマイク権限や入力デバイス状態に依存する挙動までは未確認です
- `start()` 失敗時にクラッシュは回避されますが、失敗理由の通知やログ強化は本PRでは未対応です
- リポジトリ全体の依存関係ビルド不整合が残っているため、Ready 化前に別途解消が必要です

## Device Testing Requirement
- needs-device-test
- 変更はクラッシュ経路の除去のみですが、音声入力まわりは実機依存のため実機確認が必要です