### PR TITLE
Issue #188 CommandSelectionViewController の storyboard/as 強制キャストを安全化

### DIFF
--- a/ZIGSIMPlus/Views/CommandSelectionViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSelectionViewController.swift
@@ -56,8 +56,19 @@ final class CommandSelectionViewController: UIViewController {
         // Get detail view controller
         switch command {
         case .compass, .ndi, .arkit, .beacon, .imageDetection:
-            // swiftlint:disable:next line_length force_cast
-            let vc = storyboard!.instantiateViewController(withIdentifier: "CommandDetailSettingsView") as! CommandDetailSettingsViewController
+            guard let storyboard else {
+                NSLog("Missing storyboard in CommandSelectionViewController.")
+                assertionFailure("Missing storyboard in CommandSelectionViewController.")
+                return
+            }
+            let viewController = storyboard.instantiateViewController(
+                withIdentifier: "CommandDetailSettingsView"
+            )
+            guard let vc = viewController as? CommandDetailSettingsViewController else {
+                NSLog("Failed to load CommandDetailSettingsViewController.")
+                assertionFailure("Failed to load CommandDetailSettingsViewController.")
+                return
+            }
             vc.command = command
 
             // Move to detail view


### PR DESCRIPTION
## Linked Issue
- Refs #188

## Summary
- `CommandSelectionViewController` の詳細画面遷移で使っていた `storyboard!` と `as!` を除去し、nil や型不一致時にクラッシュしないようにしました。

## Scope
- `ZIGSIMPlus/Views/CommandSelectionViewController.swift`
- `showDetail(commandNo:)` 内の詳細画面生成処理のみ

## Non-goals
- Storyboard 構成の変更
- 画面遷移ロジック全体のリファクタリング
- 他画面の force unwrap / force cast 修正

## Changes
- `storyboard!` を `guard let storyboard` に変更
- `instantiateViewController` の結果を一度受けて `as? CommandDetailSettingsViewController` で安全にキャスト
- Storyboard 未設定時と identifier / 型不一致時に `NSLog` と `assertionFailure` を出して早期 return するフォールバックを追加

## Validation Commands
- `xcodebuild -project ZIGSIMPlus.xcodeproj -target ZIGSIMPlus -configuration Debug -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build`

## Results
- 該当の `storyboard!` と `as! CommandDetailSettingsViewController` は除去済み
- ビルドは実行済み
- ただしビルドは失敗しました。今回の変更箇所ではなく、依存パッケージ `OSCKitCore` のコンパイルで `SwiftASCII` / `SwiftDataParsing` の module dependency を解決できず停止しています
- 初回失敗時に発生していた SwiftLint DerivedData の壊れた `build` ファイルは削除して再実行済みです

## Risks
- フォールバック時は詳細画面へ遷移せず、その場で return します
- ログと assertion は出ますが、ユーザー向けエラーダイアログは追加していません
- 依存パッケージ由来のビルド失敗が継続しているため、最終的な受け入れ条件のビルド成功は別途確認が必要です

## Device Test Requirements
- 実機テスト不要
- `needs-device-test` は不要
