### PR TITLE
Issue #202 CommandSettingViewController のライフサイクルメソッドを本体クラスへ移動

### DIFF
--- a/ZIGSIMPlus/Views/CommandSettingViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSettingViewController.swift
@@ -60,6 +60,16 @@ public class CommandSettingViewController: UIViewController {
         initNavigationBar()
     }
 
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        configureObserver()
+    }
+
+    public override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        removeObserver()
+    }
+
     public override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         if updateSettingTextData() {
             view.endEditing(true)
@@ -152,16 +162,6 @@ extension CommandSettingViewController: UITextFieldDelegate {
 }
 
 extension CommandSettingViewController: ContentScrollable {
-    public override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        configureObserver()
-    }
-
-    public override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        removeObserver()
-    }
-
     func configureObserver() {
         showObserver = NotificationCenter.default.addObserver(
             forName: UIResponder.keyboardWillShowNotification,


### PR DESCRIPTION
# Summary

- `CommandSettingViewController` の `viewWillAppear` / `viewWillDisappear` を `ContentScrollable` extension から本体クラスへ移動しました。

---

# Related Issue

Closes #202

---

# Scope

## In Scope

- `viewWillAppear(_:)` / `viewWillDisappear(_:)` の定義場所を本体クラスへ移動
- `ContentScrollable` extension にはキーボード監視のヘルパーメソッドのみを残す

## Out of Scope (Non-goals)

- `ContentScrollable` プロトコル設計の変更
- 他の ViewController のライフサイクル整理
- スクロール挙動そのものの変更

---

# Changes

- `CommandSettingViewController` 本体に `viewWillAppear(_:)` を追加し、従来通り `configureObserver()` を呼ぶようにしました。
- `CommandSettingViewController` 本体に `viewWillDisappear(_:)` を追加し、従来通り `removeObserver()` を呼ぶようにしました。
- `extension CommandSettingViewController: ContentScrollable` から override を削除し、補助メソッドだけを残しました。

---

# Validation

## Commands Run

- `xcodebuild -list -workspace ZIGSIMPlus.xcworkspace`
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -destination 'generic/platform=iOS' build`

## Results

- ワークスペースとスキームの解決に成功しました。
- `ZIGSIMPlus` の iOS 向けビルドは成功しました。
- 既存の SwiftLint / asset catalog / script phase 由来の warning は出ていますが、本対応に起因する新規エラーはありません。

---

# Device Testing

- Status: Not required
- Notes: ライフサイクルメソッドの定義場所移動のみで、挙動変更は意図していません。

---

# Risks / Concerns

- 変更対象は 1 ファイルのみでリスクは低い想定です。
-  issue の記載パスは `ZIGSIMPlus/ViewControllers/...` でしたが、実ファイルは `ZIGSIMPlus/Views/CommandSettingViewController.swift` だったため、実ファイル側を修正しています。

---

# Additional Notes

- 作業ツリーに別件の `ZIGSIMPlus/Models/Services/LocationService.swift` 変更がありましたが、この PR には含めていません。

# Checklist

- [x] Branch is created from `modernize`
- [x] PR targets `modernize`
- [x] Scope matches Issue
- [x] No unrelated changes included
- [x] Validation commands were executed
- [x] Risks are documented
- [x] Device testing requirement is stated