### PR TITLE
Issue #200 CommandPlayer の fatalError を nil 安全な false フォールバックへ置き換え

### DIFF
--- a/ZIGSIMPlus/Models/CommandPlayer.swift
+++ b/ZIGSIMPlus/Models/CommandPlayer.swift
@@ -115,10 +115,7 @@ public class CommandPlayer {
     }
 
     private func isActive(_ command: Command) -> Bool {
-        guard let res = AppSettingModel.shared.isActiveByCommand[command] else {
-            fatalError("AppSetting for Command \"\(command)\" is nil")
-        }
-        return res
+        AppSettingModel.shared.isActiveByCommand[command] ?? false
     }
 
     private func enqueueNetworkSend() {


### PR DESCRIPTION
# Summary

- `CommandPlayer.isActive(_:)` の `fatalError` を除去し、`isActiveByCommand[command]` が `nil` の場合は `false` を返すように変更しました。

---

# Related Issue

Closes #200

---

# Scope

## In Scope

- `ZIGSIMPlus/Models/CommandPlayer.swift` の対象箇所のみを修正
- `isActiveByCommand[command]` が `nil` のときの挙動をクラッシュから `false` 返却へ変更

## Out of Scope (Non-goals)

- `isActiveByCommand` の初期化ロジック変更
- `CommandPlayer` の設計変更
- 他ファイルの `fatalError` 対応

---

# Changes

- `CommandPlayer.isActive(_:)` の `fatalError` を削除しました。
- `AppSettingModel.shared.isActiveByCommand[command] ?? false` に置き換えました。
- 影響範囲は `ZIGSIMPlus/Models/CommandPlayer.swift` のみです。

---

# Validation

## Commands Run

- `xcodebuild -list -workspace ZIGSIMPlus.xcworkspace`
- `git submodule update --init --recursive`
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -destination 'generic/platform=iOS' build`

## Results

- `xcodebuild -list -workspace ZIGSIMPlus.xcworkspace`: 成功
- `git submodule update --init --recursive`: 成功
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -destination 'generic/platform=iOS' build`: 失敗
- 失敗理由: リンカで `ld: library 'ndi_ios' not found` が発生しました。今回の変更箇所ではなく、ローカル環境の依存ライブラリ解決が未完了の状態です。

---

# Device Testing

- Status: Not required
- Notes: ロジック上の nil フォールバック変更のみで UI や実機依存の挙動変更はありません。

---

# Risks / Concerns

- `isActiveByCommand[command]` が未初期化でもクラッシュせず非アクティブ扱いになるため、従来の即時クラッシュ検知は行われなくなります。
- 受け入れ条件のビルド成功は、現状の `ndi_ios` リンカ依存のためこの環境では未達です。

---

# Additional Notes

- 変更は Issue #200 の範囲に限定しています。
- 実機テストは未実施です。

# Checklist

- [x] Branch is created from `modernize`
- [x] PR targets `modernize`
- [x] Scope matches Issue
- [x] No unrelated changes included
- [x] Validation commands were executed
- [x] Risks are documented
- [x] Device testing requirement is stated