### PR TITLE
Issue #206 NetworkAdapter の sendUDP を async/await 化し sendTCP と対称にする

### DIFF
--- a/ZIGSIMPlus/Models/NetworkAdapter.swift
+++ b/ZIGSIMPlus/Models/NetworkAdapter.swift
@@ -72,10 +72,7 @@ public class NetworkAdapter {
         case .TCP:
             try await sendTCP(data)
         case .UDP:
-            sendUDP(data)
-            if let error = error {
-                throw error
-            }
+            try await sendUDP(data)
         }
     }
 
@@ -196,14 +193,14 @@ public class NetworkAdapter {
         }
     }
 
-    private func sendUDP(_ data: Data) {
+    private func sendUDP(_ data: Data) async throws {
         assert(!Thread.isMainThread)
 
         let appSetting = AppSettingModel.shared
 
         guard let nwPort = NWEndpoint.Port(rawValue: UInt16(appSetting.portNumber)) else {
             error = NetworkError.queryFailed
-            return
+            throw NetworkError.queryFailed
         }
 
         let conn = NWConnection(
@@ -212,33 +209,42 @@ public class NetworkAdapter {
             using: .udp
         )
 
-        let semaphore = DispatchSemaphore(value: 0)
-        var sendError: Error?
+        do {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                let gate = ConnectionContinuationGate(continuation)
 
-        conn.stateUpdateHandler = { state in
-            switch state {
-            case .ready:
-                conn.send(content: data, completion: .contentProcessed { nwError in
-                    sendError = nwError
-                    conn.cancel()
-                    semaphore.signal()
-                })
-            case .failed(let err):
-                sendError = err
-                semaphore.signal()
-            default:
-                break
+                conn.stateUpdateHandler = { state in
+                    switch state {
+                    case .ready:
+                        conn.send(content: data, completion: .contentProcessed { nwError in
+                            conn.cancel()
+                            if let nwError = nwError {
+                                gate.resume(throwing: nwError)
+                            } else {
+                                gate.resume()
+                            }
+                        })
+                    case .failed(let err):
+                        gate.resume(throwing: err)
+                    case .cancelled:
+                        gate.resume(throwing: NetworkError.connectionClosed)
+                    default:
+                        break
+                    }
+                }
+                conn.start(queue: connectionQueue)
+
+                connectionQueue.asyncAfter(deadline: .now() + 1.0) {
+                    if gate.resume(throwing: NetworkError.connectionTimeout) {
+                        conn.cancel()
+                    }
+                }
             }
-        }
-        conn.start(queue: connectionQueue)
-
-        if semaphore.wait(timeout: .now() + 1.0) == .timedOut {
-            conn.cancel()
-            error = NetworkError.connectionTimeout
-        } else if let err = sendError {
-            error = mapNWError(err)
-        } else {
             error = nil
+        } catch {
+            let networkError = mapNetworkError(error)
+            self.error = networkError
+            throw networkError
         }
     }
 


### PR DESCRIPTION
## Linked Issue
- Closes #206

## Summary
- `NetworkAdapter` の UDP 送信処理を `async/await` 化し、TCP 送信と同じエラー伝播パターンに統一しました。

## Scope
- `ZIGSIMPlus/Models/NetworkAdapter.swift` のみを変更しました。
- `sendUDP(_:)` を `async throws` に変更しました。
- `send()` の UDP 分岐を `try await sendUDP(data)` に変更しました。
- UDP の `NWConnection` コールバックを `withCheckedThrowingContinuation` と既存の `ConnectionContinuationGate` でラップしました。
- 1 秒タイムアウトを `connectionQueue.asyncAfter(deadline: .now() + 1.0)` で実装しました。
- UDP エラーの `self.error` への直接書き込みをやめ、`throw` を起点にした伝播へ寄せました。

## Non-goals
- `sendTCP` の実装変更
- `ConnectionContinuationGate` の設計変更
- UDP 接続管理方式の変更
- キャンセル対応の追加
- `NetworkAdapter` 以外のファイル変更

## Changes
- `DispatchSemaphore.wait` を削除しました。
- UDP 送信成功時は `error = nil`、失敗時は `mapNetworkError(_:)` で `NetworkError` に正規化して `throw` する形へ変更しました。
- UDP は従来どおり送信ごとに新規 `NWConnection` を生成し、完了時またはタイムアウト時に `cancel()` する動作を維持しています。

## Validation steps
- `xcodebuild -list -workspace ZIGSIMPlus.xcworkspace`
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -configuration Debug -destination 'generic/platform=iOS' build`

## Results
- `xcodebuild -list` は成功し、workspace / scheme 解決を確認しました。
- `xcodebuild ... build` はこのマシンの Xcode 環境に `iOS 26.4` プラットフォームが未導入のため未完了でした。
- そのため、ビルド成功はこの環境では未確認です。

## Risks
- ローカルの iOS プラットフォーム未導入により、プロジェクト全体の実ビルド検証が未完了です。
- 実装上は `ConnectionContinuationGate` でタイムアウトとコールバックの二重 resume を抑止していますが、最終的なコンパイル確認は Xcode 環境整備後に再実施が必要です。

## Device test requirements
- 実機テスト不要
- `needs-device-test`: 不要