### PR TITLE
StandardCell の VC 強参照を delegate パターンに置き換えてメモリリークリスクを除去する

### DIFF
--- a/ZIGSIMPlus/Presenters/CommandSelectionPresenter.swift
+++ b/ZIGSIMPlus/Presenters/CommandSelectionPresenter.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-protocol CommandSelectionPresenterProtocol {
+protocol CommandSelectionPresenterProtocol: AnyObject {
     var numberOfCommandToSelect: Int { get }
     func getCommandToSelect(forRow row: Int) -> CommandToSelect
     func didSelectRow(atLabel labelString: String)

--- a/ZIGSIMPlus/Views/CommandSelectionViewController.swift
+++ b/ZIGSIMPlus/Views/CommandSelectionViewController.swift
@@ -156,7 +156,7 @@ extension CommandSelectionViewController: UITableViewDataSource {
         cell.commandLabel.text = commandToSelect.labelString
         cell.commandLabel.tag = indexPath.row
         cell.commandOnOffButton.tag = indexPath.row
-        cell.viewController = self
+        cell.delegate = self
         cell.commandSelectionPresenter = presenter
         cells[Command.allCases[indexPath.row]] = cell
 
@@ -221,3 +221,5 @@ extension CommandSelectionViewController: UITableViewDataSource {
 }
 
 extension CommandSelectionViewController: CommandSelectionPresenterDelegate {}
+
+extension CommandSelectionViewController: StandardCellDelegate {}

--- a/ZIGSIMPlus/Views/CustomCells/StandardCell.swift
+++ b/ZIGSIMPlus/Views/CustomCells/StandardCell.swift
@@ -9,6 +9,13 @@
 import Foundation
 import UIKit
 
+protocol StandardCellDelegate: AnyObject {
+    func showDetail(commandNo: Int)
+    func showModal(commandNo: Int)
+    func setSelectedButtonAvailable(_ selectedCommandNo: Int)
+    func setNdiArkitImageDetectionButtonAvailable()
+}
+
 public class StandardCell: UITableViewCell {
     @IBOutlet var commandOnOffButton: UIButton!
     @IBOutlet var commandLabel: UILabel!
@@ -17,28 +24,26 @@ public class StandardCell: UITableViewCell {
     @IBOutlet var detailImageView: UIImageView!
     @IBOutlet var modalButton: UIButton!
     @IBOutlet var labelConstaint: NSLayoutConstraint!
-    var commandSelectionPresenter: CommandSelectionPresenterProtocol!
-    var viewController: UIViewController!
+    weak var commandSelectionPresenter: CommandSelectionPresenterProtocol?
+    weak var delegate: StandardCellDelegate?
 
     @IBAction func commandOnOffButtonAction(_ sender: UIButton) {
         setCheckMarkLabelText()
         setCommandsOfImageAvailability(sender)
         if checkMarkLabel.text == checkMark {
-            commandSelectionPresenter.saveCommandOnOffToUserDefaults(Command.allCases[sender.tag], true)
+            commandSelectionPresenter?.saveCommandOnOffToUserDefaults(Command.allCases[sender.tag], true)
         } else {
-            commandSelectionPresenter.saveCommandOnOffToUserDefaults(Command.allCases[sender.tag], false)
+            commandSelectionPresenter?.saveCommandOnOffToUserDefaults(Command.allCases[sender.tag], false)
         }
-        commandSelectionPresenter.didSelectRow(atLabel: Command.allCases[sender.tag].rawValue)
+        commandSelectionPresenter?.didSelectRow(atLabel: Command.allCases[sender.tag].rawValue)
     }
 
     @IBAction func detailButtonAction(_: UIButton) {
-        guard let parent = viewController as? CommandSelectionViewController else { return }
-        parent.showDetail(commandNo: commandOnOffButton.tag)
+        delegate?.showDetail(commandNo: commandOnOffButton.tag)
     }
 
     @IBAction func modalButtonAction(_: UIButton) {
-        guard let parent = viewController as? CommandSelectionViewController else { return }
-        parent.showModal(commandNo: commandLabel.tag)
+        delegate?.showModal(commandNo: commandLabel.tag)
     }
 
     func initCell() {
@@ -52,14 +57,13 @@ public class StandardCell: UITableViewCell {
     }
 
     func setCommandsOfImageAvailability(_ sender: UIButton) {
-        guard let parent = viewController as? CommandSelectionViewController else { return }
         if Command.allCases[sender.tag] == .ndi ||
             Command.allCases[sender.tag] == .arkit ||
             Command.allCases[sender.tag] == .imageDetection {
             if checkMarkLabel.text == checkMark {
-                parent.setSelectedButtonAvailable(sender.tag)
+                delegate?.setSelectedButtonAvailable(sender.tag)
             } else {
-                parent.setNdiArkitImageDetectionButtonAvailable()
+                delegate?.setNdiArkitImageDetectionButtonAvailable()
             }
         }
     }


### PR DESCRIPTION
# Summary

`StandardCell` が `UIViewController` を直接保持していた参照を delegate パターンへ置き換え、セル起点の画面操作を疎結合化しました。

---

# Related Issue

Closes #208

---

# Scope

## In Scope

- `StandardCellDelegate` の追加
- `StandardCell` の VC 強参照除去と delegate 経由への置換
- `CommandSelectionViewController` での delegate 設定
- `CommandSelectionPresenterProtocol` の class-bound 化による weak 参照対応

## Out of Scope (Non-goals)

- `.xib` / Storyboard の接続変更
- `CommandSelectionPresenter` のロジック変更
- `CommandSelectionViewController` の関連しないリファクタリング
- `cellForRowAt` 内の `as! StandardCell` force cast 修正
- UI レイアウト変更

---

# Changes

- `StandardCell.swift` に `StandardCellDelegate` を定義し、`viewController` を `weak var delegate` に置き換えました
- セル内の `detailButtonAction` / `modalButtonAction` / 画像系コマンド切替通知を delegate 呼び出しへ変更しました
- `CommandSelectionPresenterProtocol` を `AnyObject` 準拠にして、`StandardCell` 側の presenter 参照を `weak` 化しました
- `CommandSelectionViewController` を `StandardCellDelegate` に適合させ、`cellForRowAt` で `cell.delegate = self` を設定しました

---

# Validation

## Commands Run

- `xcodebuild -list -workspace ZIGSIMPlus.xcworkspace`
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -destination 'generic/platform=iOS Simulator' build`
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -destination 'generic/platform=iOS Simulator' build -quiet`
- `xcodebuild -workspace ZIGSIMPlus.xcworkspace -scheme ZIGSIMPlus -destination 'generic/platform=iOS Simulator' -derivedDataPath /private/tmp/zigsim_issue208_dd build -quiet`
- `rg -n "viewController as\\? CommandSelectionViewController|var viewController: UIViewController!|cell\\.viewController = self|cell\\.delegate = self|protocol StandardCellDelegate|weak var delegate: StandardCellDelegate\\?|weak var commandSelectionPresenter: CommandSelectionPresenterProtocol\\?" ZIGSIMPlus`

## Results

- ワークスペース/スキームの解決は成功し、`ZIGSIMPlus` スキームを確認しました
- ビルド再実行のうち 1 回は並行実行の影響で `build.db` lock により失敗しました
- 分離した `DerivedData` を使った simulator build は、`Private/Prototypes/NDISwift/ofxNDI/libs/NDI/lib/ios/libndi_ios.a` が `iOS` 向けで `iOS Simulator` へリンクできない既存要因により失敗しました
- Issue #208 の変更箇所に起因する Swift コンパイルエラーはこのビルド結果では確認していません
- `rg` により `StandardCell` 内の `viewController` 保持と `cell.viewController = self` 代入が除去され、`delegate`/`weak presenter` への置換が入っていることを確認しました

---

# Device Testing

- Status: Pending (`needs-device-test`)
- Notes: 実機でコマンド ON/OFF、詳細画面遷移、モーダル表示、および NDI/ARKit/Image Detection の排他制御確認が必要です

---

# Risks / Concerns

- 実機での画面遷移と排他制御の動作確認は未実施です
- `iOS Simulator` build は NDI 静的ライブラリの既存リンク問題で失敗しており、この Issue 単体での完全なビルド成功確認はできていません

---

# Additional Notes

- 変更は Issue #208 の対象 3 ファイルに限定しています
- PR は `modernize` 向け Draft を想定しています

# Checklist

- [x] Branch is created from `modernize`
- [x] PR targets `modernize`
- [x] Scope matches Issue
- [x] No unrelated changes included
- [x] Validation commands were executed
- [x] Risks are documented
- [x] Device testing requirement is stated
